### PR TITLE
変愚「https://github.com/hengband/hengband/pull/4816」のマージ

### DIFF
--- a/src/dungeon/dungeon-processor.cpp
+++ b/src/dungeon/dungeon-processor.cpp
@@ -190,7 +190,7 @@ void process_dungeon(PlayerType *player_ptr, bool load_game)
     }
 
     const auto &dungeon = floor.get_dungeon_definition();
-    if (floor.dun_level == dungeon.maxdepth) {
+    if (dungeon.has_guardian() && (floor.dun_level == dungeon.maxdepth)) {
         const auto &monrace = dungeon.get_guardian();
         if (!monrace.is_dead_unique()) {
 #ifdef JP


### PR DESCRIPTION
f1e668fb によるエンバグ。
元々きちんとダンジョンの主が存在するかどうかのチェックをするべきで
あるところなので、先に has_guardian() による判定を行うようにする。