### PR TITLE
変愚「[Fix] ランダムVault生成でクラッシュ #4826」のマージ

### DIFF
--- a/src/room/rooms-vault.cpp
+++ b/src/room/rooms-vault.cpp
@@ -179,7 +179,7 @@ static void build_bubble_vault(PlayerType *player_ptr, const Pos2D &pos0, const 
 /* Create a random vault that looks like a collection of overlapping rooms */
 static void build_room_vault(PlayerType *player_ptr, const Pos2D &center, const Pos2DVec &vec)
 {
-    const Pos2DVec vec_half(vec.x / 2, vec.y / 2);
+    const Pos2DVec vec_half(vec.y / 2, vec.x / 2);
     msg_print_wizard(player_ptr, CHEAT_DUNGEON, _("部屋型ランダムVaultを生成しました。", "Room Vault."));
 
     /* fill area so don't get problems with on_defeat_arena_monster levels */


### PR DESCRIPTION
部屋のサイズのxとyを取り違えているため配列範囲外アクセスが発生している
のが原因。正しく修正する。