### PR TITLE
変愚「[Refactor] in_disintegration_range()のシグネチャを変更 #4869」のマージ

### DIFF
--- a/src/effect/effect-processor.cpp
+++ b/src/effect/effect-processor.cpp
@@ -230,7 +230,7 @@ ProjectResult project(PlayerType *player_ptr, const MONSTER_IDX src_idx, POSITIO
                             }
                             break;
                         case AttributeType::DISINTEGRATE:
-                            if (!in_disintegration_range(player_ptr->current_floor_ptr, pos_breath.y, pos_breath.x, y, x)) {
+                            if (!in_disintegration_range(floor, pos_breath, pos)) {
                                 continue;
                             }
                             break;

--- a/src/monster-floor/monster-direction.cpp
+++ b/src/monster-floor/monster-direction.cpp
@@ -86,7 +86,7 @@ static void decide_enemy_approch_direction(PlayerType *player_ptr, MONSTER_IDX m
         const auto m_pos_from = monster_from.get_position();
         const auto m_pos_to = monster_to.get_position();
         if (can_pass_wall || can_kill_wall) {
-            if (!in_disintegration_range(&floor, m_pos_from.y, m_pos_from.x, m_pos_to.y, m_pos_to.x)) {
+            if (!in_disintegration_range(floor, m_pos_from, m_pos_to)) {
                 continue;
             }
         } else {

--- a/src/mspell/mspell-judgement.cpp
+++ b/src/mspell/mspell-judgement.cpp
@@ -124,10 +124,10 @@ bool breath_direct(PlayerType *player_ptr, const Pos2D &pos_source, const Pos2D 
     if (path_n == 0) {
         const auto p_pos = player_ptr->get_position();
         if (flg & PROJECT_DISI) {
-            if (in_disintegration_range(&floor, pos_source.y, pos_source.x, pos_target.y, pos_target.x) && (Grid::calc_distance(pos_source, pos_target) <= rad)) {
+            if (in_disintegration_range(floor, pos_source, pos_target) && (Grid::calc_distance(pos_source, pos_target) <= rad)) {
                 hit2 = true;
             }
-            if (in_disintegration_range(&floor, pos_source.y, pos_source.x, p_pos.y, p_pos.x) && (Grid::calc_distance(pos_source, p_pos) <= rad)) {
+            if (in_disintegration_range(floor, pos_source, p_pos) && (Grid::calc_distance(pos_source, p_pos) <= rad)) {
                 hityou = true;
             }
         } else if (flg & PROJECT_LOS) {

--- a/src/mspell/mspell-lite.cpp
+++ b/src/mspell/mspell-lite.cpp
@@ -136,7 +136,7 @@ static void check_lite_area_by_mspell(PlayerType *player_ptr, msa_type *msa_ptr)
     const auto pos = msa_ptr->get_position();
     const auto m_pos = msa_ptr->m_ptr->get_position();
     const auto &floor = *player_ptr->current_floor_ptr;
-    light_by_disintegration &= in_disintegration_range(&floor, m_pos.y, m_pos.x, pos.y, pos.x);
+    light_by_disintegration &= in_disintegration_range(floor, m_pos, pos);
     light_by_disintegration &= one_in_(10) || (projectable(player_ptr, pos, m_pos) && one_in_(2));
     if (light_by_disintegration) {
         msa_ptr->do_spell = DO_SPELL_BR_DISI;

--- a/src/spell-realm/spells-crusade.cpp
+++ b/src/spell-realm/spells-crusade.cpp
@@ -91,7 +91,7 @@ bool cast_wrath_of_the_god(PlayerType *player_ptr, int dam, POSITION rad)
         }
 
         auto should_cast = in_bounds(&floor, pos_explode.y, pos_explode.x) && !cave_stop_disintegration(&floor, pos_explode.y, pos_explode.x);
-        should_cast &= in_disintegration_range(&floor, pos_target.y, pos_target.x, pos_explode.y, pos_explode.x);
+        should_cast &= in_disintegration_range(floor, pos_target, pos_explode);
         if (!should_cast) {
             continue;
         }

--- a/src/spell/range-calc.h
+++ b/src/spell/range-calc.h
@@ -9,6 +9,6 @@
 class FloorType;
 class PlayerType;
 class ProjectionPath;
-bool in_disintegration_range(const FloorType *floor_ptr, POSITION y1, POSITION x1, POSITION y2, POSITION x2);
+bool in_disintegration_range(const FloorType &floor, const Pos2D &pos1, const Pos2D &pos2);
 void breath_shape(PlayerType *player_ptr, const ProjectionPath &path, int dist, int *pgrids, std::span<Pos2D> positions, std::span<int> gm, int *pgm_rad, int rad, const Pos2D &pos_source, const Pos2D &pos_target, AttributeType typ);
 POSITION dist_to_line(POSITION y, POSITION x, POSITION y1, POSITION x1, POSITION y2, POSITION x2);


### PR DESCRIPTION
los() と同様Pos2D型の引数を使用したシグネチャに変更し、それに伴い
呼び出し箇所を修正する。
ちなみに in_disintegration_range() は los() と !cave_los_bold か cave_stop_disintegration のどちらを呼ぶか以外にロジックに違いがない
コピペコードのようである。