### PR TITLE
変愚「[Feature] 自動拾いエディタのカーソル上下の挙動を自然にする #4880」のマージ

### DIFF
--- a/src/autopick/autopick-util.h
+++ b/src/autopick/autopick-util.h
@@ -42,8 +42,13 @@ struct autopick_type {
 class ItemEntity;
 struct text_body_type {
     text_body_type(int cx, int cy); //!< @details 画面表示はX→Yの順番であることが多いので一応揃える.
+
+    void adjust_cursor_column();
+    void update_cursor_column_record(int com_id);
+
     int cx;
     int cy;
+    int rec_cx = 0;
     int wid = 0;
     int hgt = 0;
     int upper = 0;

--- a/src/cmd-io/cmd-autopick.cpp
+++ b/src/cmd-io/cmd-autopick.cpp
@@ -21,7 +21,7 @@
 #include "util/finalizer.h"
 #include "util/int-char-converter.h"
 #include "world/world.h"
-#include <ctime>
+#include <set>
 
 text_body_type::text_body_type(int cx, int cy)
     : cx(cx)
@@ -102,6 +102,20 @@ static int analyze_move_key(text_body_type *tb, uint32_t skey)
     return com_id;
 }
 
+void text_body_type::adjust_cursor_column()
+{
+    this->cx = std::max(this->cx, this->rec_cx);
+    this->cx = std::min<int>(this->lines_list[this->cy]->length(), this->cx);
+}
+
+void text_body_type::update_cursor_column_record(int com_id)
+{
+    static const std::set record_cursor_column_commands = { EC_UP, EC_DOWN, EC_PGUP, EC_PGDOWN, EC_TOP, EC_BOTTOM };
+
+    const auto should_record = record_cursor_column_commands.contains(com_id);
+    this->rec_cx = should_record ? std::max(this->cx, this->rec_cx) : 0;
+}
+
 /*
  * In-game editor of Object Auto-picker/Destoryer
  * @param player_ptr プレイヤーへの参照ポインタ
@@ -151,6 +165,7 @@ void do_cmd_edit_autopick(PlayerType *player_ptr)
     screen_save();
     while (quit == APE_QUIT) {
         int com_id = 0;
+        tb->adjust_cursor_column();
         draw_text_editor(player_ptr, tb);
         prt(_("(^Q:終了 ^W:セーブして終了, ESC:メニュー, その他:入力)",
                 "(^Q:Quit, ^W:Save&Quit, ESC:Menu, Other:Input text)"),
@@ -184,7 +199,6 @@ void do_cmd_edit_autopick(PlayerType *player_ptr)
             }
 
             insert_single_letter(tb, key);
-            continue;
         } else {
             com_id = get_com_id((char)key);
         }
@@ -192,6 +206,8 @@ void do_cmd_edit_autopick(PlayerType *player_ptr)
         if (com_id) {
             quit = do_editor_command(player_ptr, tb, com_id);
         }
+
+        tb->update_cursor_column_record(com_id);
     }
 
     screen_load();


### PR DESCRIPTION
自動エディタのカーソルを上下方向に動かした時（スクロールアップ/ダウンや
エディタの先頭行・最終行への移動を含む）に、移動前の行より短い行に
移動した場合にカーソルの位置も短い行にあわせて移動させる。
またその行から長い行に行った場合に元のカーソルの位置に戻そうとする。