### PR TITLE
変愚「[Refactor] 床と壁の確率による選択 #4885」のマージ

### DIFF
--- a/src/info-reader/dungeon-reader.cpp
+++ b/src/info-reader/dungeon-reader.cpp
@@ -110,6 +110,24 @@ static bool grab_one_spell_monster_flag(DungeonDefinition &dungeon, std::string_
     return false;
 }
 
+static std::optional<ProbabilityTable<short>> parse_terrain_probability(std::span<const std::string> tokens)
+{
+    const auto &terrains = TerrainList::get_instance();
+    ProbabilityTable<short> prob_table;
+
+    for (auto i = 0; std::cmp_less(i + 1, tokens.size()); i += 2) {
+        try {
+            const auto terrain_id = terrains.get_terrain_id(tokens[i]);
+            const auto prob = static_cast<short>(std::stoi(tokens[i + 1]));
+            prob_table.entry_item(terrain_id, prob);
+        } catch (const std::exception &) {
+            return std::nullopt;
+        }
+    }
+
+    return prob_table;
+}
+
 /*!
  * @brief ダンジョン情報(DungeonsDefinition)のパース関数 /
  * @param buf テキスト列
@@ -220,48 +238,37 @@ errr parse_dungeons_info(std::string_view buf, angband_header *)
     }
 
     // L:floor_1:prob_1:floor_2:prob_2:floor_3:prob_3:tunnel_prob
+    constexpr auto terrain_probability_num = 3;
     if (tokens[0] == "L") {
-        if (tokens.size() < TERRAIN_PROBABILITY_NUM * 2 + 2) {
+        if (tokens.size() < terrain_probability_num * 2 + 2) {
             return PARSE_ERROR_TOO_FEW_ARGUMENTS;
         }
 
-        for (size_t i = 0; i < TERRAIN_PROBABILITY_NUM; i++) {
-            auto feat_idx = i * 2 + 1;
-            auto per_idx = feat_idx + 1;
-            try {
-                dungeon->floor[i].terrain_id = terrains.get_terrain_id(tokens[feat_idx]);
-            } catch (const std::exception &) {
-                return PARSE_ERROR_UNDEFINED_TERRAIN_TAG;
-            }
-
-            info_set_value(dungeon->floor[i].chance, tokens[per_idx]);
+        auto prob_table = parse_terrain_probability(std::span(tokens.begin() + 1, terrain_probability_num * 2));
+        if (!prob_table) {
+            return PARSE_ERROR_UNDEFINED_TERRAIN_TAG;
         }
+        dungeon->prob_table_floor = std::move(*prob_table);
 
-        auto tunnel_idx = TERRAIN_PROBABILITY_NUM * 2 + 1;
+        auto tunnel_idx = terrain_probability_num * 2 + 1;
         info_set_value(dungeon->tunnel_percent, tokens[tunnel_idx]);
         return PARSE_ERROR_NONE;
     }
 
     // A:wall_1:prob_1:wall_2:prob_2:wall_3:prob_3:outer_wall:inner_wall:stream_1:stream_2
     if (tokens[0] == "A") {
-        if (tokens.size() < TERRAIN_PROBABILITY_NUM * 2 + 5) {
+        if (tokens.size() < terrain_probability_num * 2 + 5) {
             return PARSE_ERROR_TOO_FEW_ARGUMENTS;
         }
 
-        for (int i = 0; i < TERRAIN_PROBABILITY_NUM; i++) {
-            auto feat_idx = i * 2 + 1;
-            auto prob_idx = feat_idx + 1;
-            try {
-                dungeon->fill[i].terrain_id = terrains.get_terrain_id(tokens[feat_idx]);
-            } catch (const std::exception &) {
-                return PARSE_ERROR_UNDEFINED_TERRAIN_TAG;
-            }
-
-            info_set_value(dungeon->fill[i].chance, tokens[prob_idx]);
+        auto prob_table = parse_terrain_probability(std::span(tokens.begin() + 1, terrain_probability_num * 2));
+        if (!prob_table) {
+            return PARSE_ERROR_UNDEFINED_TERRAIN_TAG;
         }
+        dungeon->prob_table_wall = std::move(*prob_table);
 
         try {
-            const std::span tags(tokens.begin() + TERRAIN_PROBABILITY_NUM * 2 + 1, 4);
+            const std::span tags(tokens.begin() + terrain_probability_num * 2 + 1, 4);
             dungeon->outer_wall = terrains.get_terrain_id(tags[0]);
             dungeon->inner_wall = terrains.get_terrain_id(tags[1]);
             dungeon->stream1 = terrains.get_terrain_id(tags[2]);

--- a/src/system/dungeon/dungeon-definition.cpp
+++ b/src/system/dungeon/dungeon-definition.cpp
@@ -195,12 +195,12 @@ DoorKind DungeonDefinition::select_door_kind() const
 
 short DungeonDefinition::select_floor_terrain_id() const
 {
-    return rand_choice(this->floor_terrain_ids);
+    return this->prob_table_floor.pick_one_at_random();
 }
 
 short DungeonDefinition::select_wall_terrain_id() const
 {
-    return rand_choice(this->wall_terrain_ids);
+    return this->prob_table_wall.pick_one_at_random();
 }
 
 void DungeonDefinition::set_guardian_flag()
@@ -209,49 +209,6 @@ void DungeonDefinition::set_guardian_flag()
         auto &monrace = this->get_guardian();
         monrace.misc_flags.set(MonsterMiscType::GUARDIAN);
     }
-}
-
-void DungeonDefinition::set_floor_terrain_ids()
-{
-    this->floor_terrain_ids = this->make_terrain_ids(this->floor);
-}
-
-void DungeonDefinition::set_wall_terrain_ids()
-{
-    this->wall_terrain_ids = this->make_terrain_ids(this->fill);
-}
-
-/*!
- * @brief 地形生成確率の決定要素を確率テーブルから作成する
- * @param is_floor 床/地面ならtrue、壁ならfalse
- */
-std::array<short, 100> DungeonDefinition::make_terrain_ids(const std::array<TerrainProbabilityEntry, TERRAIN_PROBABILITY_NUM> &prob_table)
-{
-    std::array<int, TERRAIN_PROBABILITY_NUM> limits{};
-    limits[0] = prob_table[0].chance;
-    for (auto i = 1; i < TERRAIN_PROBABILITY_NUM; i++) {
-        limits[i] = limits[i - 1] + prob_table[i].chance;
-    }
-
-    if (limits[TERRAIN_PROBABILITY_NUM - 1] < 100) {
-        limits[TERRAIN_PROBABILITY_NUM - 1] = 100;
-    }
-
-    std::array<short, 100> ids{};
-    auto cur = 0;
-    for (auto i = 0; i < 100; i++) {
-        while (i == limits[cur]) {
-            cur++;
-        }
-
-        if (cur >= TERRAIN_PROBABILITY_NUM) {
-            THROW_EXCEPTION(std::logic_error, "Invalid probability table is generated!");
-        }
-
-        ids[i] = prob_table[cur].terrain_id;
-    }
-
-    return ids;
 }
 
 MonraceDefinition &DungeonDefinition::get_guardian()

--- a/src/system/dungeon/dungeon-definition.h
+++ b/src/system/dungeon/dungeon-definition.h
@@ -23,7 +23,7 @@
 #include "room/room-types.h"
 #include "system/angband.h"
 #include "util/flag-group.h"
-#include <array>
+#include "util/probability-table.h"
 #include <optional>
 #include <string>
 #include <utility>
@@ -65,12 +65,6 @@ enum class DungeonMode {
     NOR = 4,
 };
 
-class TerrainProbabilityEntry {
-public:
-    short terrain_id{}; //!< 地形ID.
-    int chance{}; //!< 確率(%).
-};
-
 /* A structure for the != dungeon types */
 enum class DoorKind;
 enum class FixedArtifactId : short;
@@ -87,8 +81,8 @@ public:
     POSITION dy{};
     POSITION dx{};
 
-    std::array<TerrainProbabilityEntry, TERRAIN_PROBABILITY_NUM> floor{}; /* Floor probability */
-    std::array<TerrainProbabilityEntry, TERRAIN_PROBABILITY_NUM> fill{}; /* Cave wall probability */
+    ProbabilityTable<short> prob_table_floor{}; /* Floor probability */
+    ProbabilityTable<short> prob_table_wall{}; /* Cave wall probability */
     short outer_wall{}; /* 外壁の地形ID */
     short inner_wall{}; /* 内壁の地形ID */
     FEAT_IDX stream1{}; /* stream tile */
@@ -156,13 +150,7 @@ public:
 
     //!< @details ここから下は、地形など全ての定義ファイルを読み込んだ後に呼び出される初期化処理.
     void set_guardian_flag();
-    void set_floor_terrain_ids();
-    void set_wall_terrain_ids();
 
 private:
-    std::array<short, 100> floor_terrain_ids{};
-    std::array<short, 100> wall_terrain_ids{};
-
-    static std::array<short, 100> make_terrain_ids(const std::array<TerrainProbabilityEntry, TERRAIN_PROBABILITY_NUM> &prob_table);
     MonraceDefinition &get_guardian();
 };

--- a/src/system/dungeon/dungeon-list.cpp
+++ b/src/system/dungeon/dungeon-list.cpp
@@ -46,7 +46,5 @@ void DungeonList::retouch()
 {
     for (auto &[_, dungeon] : this->dungeons) {
         dungeon->set_guardian_flag();
-        dungeon->set_floor_terrain_ids();
-        dungeon->set_wall_terrain_ids();
     }
 }


### PR DESCRIPTION
100個の配列に地形IDを展開する方法からProbabilityTableクラスを使用する
方法に変更する。