### PR TITLE
変愚「[Fix] RF5_HOLDがモンスターを麻痺ではなく朦朧とさせる #4933」のマージ

### DIFF
--- a/src/mspell/mspell-status.cpp
+++ b/src/mspell/mspell-status.cpp
@@ -457,7 +457,7 @@ MonsterSpellResult spell_RF5_HOLD(MONSTER_IDX m_idx, PlayerType *player_ptr, MON
         return res;
     }
 
-    resist = (tr_ptr->kind_flags.has(MonsterKindType::UNIQUE) || tr_ptr->resistance_flags.has(MonsterResistanceType::NO_STUN));
+    resist = (tr_ptr->kind_flags.has(MonsterKindType::UNIQUE) || tr_ptr->resistance_flags.has(MonsterResistanceType::NO_SLEEP));
     saving_throw = (tr_ptr->level > randint1((rlev - 10) < 1 ? 1 : (rlev - 10)) + 10);
 
     mspell_cast_msg_bad_status_to_monster msg(_("%s^は%sをじっと見つめた。", "%s^ stares intently at %s."),
@@ -466,7 +466,7 @@ MonsterSpellResult spell_RF5_HOLD(MONSTER_IDX m_idx, PlayerType *player_ptr, MON
     spell_badstatus_message_to_mons(player_ptr, m_idx, t_idx, msg, (bool)resist, saving_throw);
 
     if (!resist && !saving_throw) {
-        (void)set_monster_stunned(player_ptr, t_idx, t_ptr->get_remaining_stun() + randint1(4) + 4);
+        (void)set_monster_csleep(player_ptr, t_idx, 500);
     }
 
     return res;


### PR DESCRIPTION
モンスターの使用する麻痺の呪文(HOLD)が対モンスターに限り麻痺でなく朦朧を与えていたバグの修正。 set_monster_stunned()は朦朧付与なので、set_monster_csleep()を使用して麻痺(睡眠)状態を付与するよう変更した。 付与する値は他の睡眠付与効果と合わせて500とした。