### PR TITLE
変愚「[Feature] 例外メッセージにアイテムの詳細情報付与 #4955」のマージ

### DIFF
--- a/src/system/item-entity.cpp
+++ b/src/system/item-entity.cpp
@@ -37,6 +37,7 @@
 #include "util/string-processor.h"
 #include "world/world.h"
 #include <algorithm>
+#include <fmt/format.h>
 #include <sstream>
 #include <vector>
 
@@ -950,7 +951,8 @@ bool ItemEntity::has_monrace() const
 const MonraceDefinition &ItemEntity::get_monrace() const
 {
     if (!this->has_monrace()) {
-        THROW_EXCEPTION(std::logic_error, "This item is not related to monrace!");
+        const auto msg = fmt::format("This item is not related to monrace!: {}", this->build_item_info_for_debug());
+        THROW_EXCEPTION(std::logic_error, msg);
     }
 
     const auto monrace_id = this->get_monrace_id();
@@ -1227,7 +1229,8 @@ int ItemEntity::get_baseitem_cost() const
 MonraceId ItemEntity::get_monrace_id() const
 {
     if (!this->has_monrace()) {
-        THROW_EXCEPTION(std::logic_error, "This item is not related to monrace!");
+        const auto msg = fmt::format("This item is not related to monrace!: {}", this->build_item_info_for_debug());
+        THROW_EXCEPTION(std::logic_error, msg);
     }
 
     return i2enum<MonraceId>(this->pval);
@@ -1579,4 +1582,10 @@ char ItemEntity::get_character() const
     const auto &baseitem = this->get_baseitem();
     const auto flavor = baseitem.flavor;
     return flavor ? BaseitemList::get_instance().get_baseitem(flavor).symbol_config.character : baseitem.symbol_config.character;
+}
+
+std::string ItemEntity::build_item_info_for_debug() const
+{
+    // とりあえず例外送出の原因となる可能性のあるフィールドのみ出力
+    return fmt::format("tval = {}, sval = {}, pval = {}", enum2i(this->bi_key.tval()), this->bi_key.sval().value_or(-1), this->pval);
 }

--- a/src/system/item-entity.h
+++ b/src/system/item-entity.h
@@ -196,4 +196,6 @@ private:
     std::string build_activation_description_dragon_breath() const;
     uint8_t get_color() const;
     char get_character() const;
+
+    std::string build_item_info_for_debug() const;
 };


### PR DESCRIPTION
エラーレポートの内容が不足しており、例外が発生したことはわかるものの
原因の絞り込みがしずらい。
例外が発生したアイテムの種別をもう少し絞り込めるようにするため、
例外メッセージにアイテムの詳細情報を付与するようにしておく。