### PR TITLE
変愚「[Refactor] Directionクラスの無効値の扱い #4965」のマージ

### DIFF
--- a/src/action/run-execution.cpp
+++ b/src/action/run-execution.cpp
@@ -35,10 +35,10 @@ byte cycle[MAX_RUN_CYCLES] = { 1, 2, 3, 6, 9, 8, 7, 4, 1, 2, 3, 6, 9, 8, 7, 4, 1
 byte chome[MAX_RUN_CHOME] = { 0, 8, 9, 10, 7, 0, 11, 6, 5, 4 };
 
 /* The direction we are running */
-static Direction find_current;
+static Direction find_current = Direction::none();
 
 /* The direction we came from */
-static Direction find_prevdir;
+static Direction find_prevdir = Direction::none();
 
 static bool find_openarea;
 
@@ -215,9 +215,9 @@ static bool run_test(PlayerType *player_ptr)
         }
     }
 
-    Direction check_dir(0);
-    std::optional<Direction> option;
-    std::optional<Direction> option2;
+    Direction check_dir(5);
+    auto option = Direction::none();
+    auto option2 = Direction::none();
     const auto max = prev_dir.is_diagonal() ? 2 : 1;
     for (auto i = -max; i <= max; i++) {
         const auto new_dir = prev_dir.rotated_45degree(i);
@@ -260,7 +260,7 @@ static bool run_test(PlayerType *player_ptr)
             inv = false;
         }
 
-        if (!inv && see_wall(player_ptr, Direction(0), pos)) {
+        if (!inv && see_wall(player_ptr, Direction(5), pos)) {
             if (find_openarea) {
                 if (i < 0) {
                     find_breakright = true;
@@ -333,20 +333,20 @@ static bool run_test(PlayerType *player_ptr)
     }
 
     if (!option2) {
-        find_current = *option;
-        find_prevdir = *option;
+        find_current = option;
+        find_prevdir = option;
         return see_wall(player_ptr, find_current, p_pos);
     } else if (!find_cut) {
-        find_current = *option;
-        find_prevdir = *option2;
+        find_current = option;
+        find_prevdir = option2;
         return see_wall(player_ptr, find_current, p_pos);
     }
 
-    const auto pos = player_ptr->get_position() + option->vec();
-    if (!see_wall(player_ptr, *option, pos) || !see_wall(player_ptr, check_dir, pos)) {
-        if (see_nothing(player_ptr, *option, pos) && see_nothing(player_ptr, *option2, pos)) {
-            find_current = *option;
-            find_prevdir = *option2;
+    const auto pos = player_ptr->get_position() + option.vec();
+    if (!see_wall(player_ptr, option, pos) || !see_wall(player_ptr, check_dir, pos)) {
+        if (see_nothing(player_ptr, option, pos) && see_nothing(player_ptr, option2, pos)) {
+            find_current = option;
+            find_prevdir = option2;
             return see_wall(player_ptr, find_current, p_pos);
         }
 
@@ -354,13 +354,13 @@ static bool run_test(PlayerType *player_ptr)
     }
 
     if (find_cut) {
-        find_current = *option2;
-        find_prevdir = *option2;
+        find_current = option2;
+        find_prevdir = option2;
         return see_wall(player_ptr, find_current, p_pos);
     }
 
-    find_current = *option;
-    find_prevdir = *option2;
+    find_current = option;
+    find_prevdir = option2;
     return see_wall(player_ptr, find_current, p_pos);
 }
 
@@ -372,7 +372,7 @@ static bool run_test(PlayerType *player_ptr)
  */
 void run_step(PlayerType *player_ptr, const Direction &dir)
 {
-    if (dir.has_direction()) {
+    if (dir) {
         ignore_avoid_run = true;
         if (see_wall(player_ptr, dir, player_ptr->get_position())) {
             sound(SoundKind::HITWALL);

--- a/src/cmd-io/cmd-gameoption.cpp
+++ b/src/cmd-io/cmd-gameoption.cpp
@@ -477,7 +477,7 @@ void do_cmd_options(PlayerType *player_ptr)
                 break;
             }
 
-            Direction d(0);
+            auto d = Direction::none();
             if (skey == SKEY_UP) {
                 d = Direction(8);
             }

--- a/src/core/player-processor.cpp
+++ b/src/core/player-processor.cpp
@@ -297,7 +297,7 @@ void process_player(PlayerType *player_ptr)
         } else if (player_ptr->action == ACTION_FISH) {
             energy.set_player_turn_energy(100);
         } else if (player_ptr->running) {
-            run_step(player_ptr, Direction(0));
+            run_step(player_ptr, Direction::none());
         } else if (travel.run) {
             travel_step(player_ptr);
         } else if (command_rep) {

--- a/src/floor/geometry.h
+++ b/src/floor/geometry.h
@@ -3,7 +3,6 @@
 #include "system/angband-exceptions.h"
 #include "system/angband.h"
 #include "util/point-2d.h"
-#include <algorithm>
 #include <array>
 #include <span>
 #include <utility>
@@ -33,7 +32,7 @@ public:
      *  /|\
      * 1 2 3
      *
-     * 0: 5と同じ
+     * 0: 無効な方向を意味する
      *
      * @param dir 方向ID
      */
@@ -45,9 +44,12 @@ public:
         }
     }
 
-    constexpr Direction()
-        : dir_(0)
+    /*!
+     * @brief 無効な方向を示す方向クラスのインスタンスを生成する
+     */
+    static constexpr Direction none()
     {
+        return Direction(0);
     }
 
     /*!
@@ -161,6 +163,15 @@ public:
         return Direction::from_cdir(new_cdir);
     }
 
+    /*!
+     * @brief インスタンスが有効な方向を示しているかどうかを返す
+     * @return 有効な方向を示している場合はtrue、そうでない場合はfalse
+     */
+    constexpr explicit operator bool() const noexcept
+    {
+        return this->dir_ != 0;
+    }
+
 private:
     /// 方向IDに対応するベクトルの定義
     static constexpr std::array<Pos2DVec, 10> DIR_TO_VEC = {
@@ -185,15 +196,10 @@ constexpr std::array<Direction, 9> DIRECTIONS = {
     { Direction(2), Direction(8), Direction(6), Direction(4), Direction(3), Direction(1), Direction(9), Direction(7), Direction(5) }
 };
 
-constexpr std::array<Direction, 9> reverse_array(const std::array<Direction, 9> &arr)
-{
-    std::array<Direction, 9> res{};
-    std::reverse_copy(arr.begin(), arr.end(), res.begin());
-    return res;
-}
-
 /// DIRECTIONSの要素を逆順にした配列
-constexpr auto REVERSE_DIRECTIONS = reverse_array(DIRECTIONS);
+constexpr std::array<Direction, 9> REVERSE_DIRECTIONS = {
+    { Direction(5), Direction(7), Direction(9), Direction(1), Direction(3), Direction(4), Direction(6), Direction(8), Direction(2) }
+};
 }
 
 /*!


### PR DESCRIPTION
現状の方向処理の扱われ方を見ると方向入力処理において0を無効値として
扱ってるので、Directionクラスでも方向ID 0を無効値として扱うようにする。
具体的には、operator bool() で有効値かどうかの判定をできるようにし、
無効値の状態のインスタンスを返す Direction::none() を追加し、
Direction(0) ではなくこれを使用することで意味をわかりやすくする。
理想的には Direction::none() 経由ではないコンストラクタ Direction(0) の 呼び出しや、無効値に対するvec()などの呼び出しは例外としたいが、現状
dir == 0を足元として使用している箇所がありそうなのでひとまず方向IDが0
でもこれらの関数の呼び出しは可能としておく。