### PR TITLE
変愚「[Fix] トラベルコマンドで移動中のディレイをなくす #4977」のマージ

### DIFF
--- a/src/action/travel-execution.cpp
+++ b/src/action/travel-execution.cpp
@@ -119,8 +119,6 @@ void travel_step(PlayerType *player_ptr)
     } else if (travel.run > 0) {
         travel.run--;
     }
-
-    term_xtra(TERM_XTRA_DELAY, delay_factor);
 }
 
 /*!


### PR DESCRIPTION
トラベルコマンドで移動している時、一歩ごとに基本ウェイト量に設定された
ディレイがかかるようになっている。
移動経路をじっくり確認できることよりも、無駄に時間がかかるデメリットの
ほうが大きいと思われるのでディレイを削除する。