### PR TITLE
変愚「[Refactor] ものまねのターゲッティング処理 #4980」のマージ

### DIFF
--- a/src/cmd-action/cmd-mane.cpp
+++ b/src/cmd-action/cmd-mane.cpp
@@ -67,8 +67,83 @@
 #include "util/enum-converter.h"
 #include "util/int-char-converter.h"
 #include "view/display-messages.h"
-
 #include <iterator>
+#include <unordered_set>
+
+namespace {
+const std::unordered_set<MonsterAbilityType> AIMING_SPELLS = {
+    MonsterAbilityType::ROCKET,
+    MonsterAbilityType::SHOOT,
+    MonsterAbilityType::BR_ACID,
+    MonsterAbilityType::BR_ELEC,
+    MonsterAbilityType::BR_FIRE,
+    MonsterAbilityType::BR_COLD,
+    MonsterAbilityType::BR_POIS,
+    MonsterAbilityType::BR_NETH,
+    MonsterAbilityType::BR_LITE,
+    MonsterAbilityType::BR_DARK,
+    MonsterAbilityType::BR_CONF,
+    MonsterAbilityType::BR_SOUN,
+    MonsterAbilityType::BR_CHAO,
+    MonsterAbilityType::BR_DISE,
+    MonsterAbilityType::BR_NEXU,
+    MonsterAbilityType::BR_TIME,
+    MonsterAbilityType::BR_INER,
+    MonsterAbilityType::BR_GRAV,
+    MonsterAbilityType::BR_SHAR,
+    MonsterAbilityType::BR_PLAS,
+    MonsterAbilityType::BR_FORC,
+    MonsterAbilityType::BR_MANA,
+    MonsterAbilityType::BA_NUKE,
+    MonsterAbilityType::BR_NUKE,
+    MonsterAbilityType::BA_CHAO,
+    MonsterAbilityType::BR_DISI,
+    MonsterAbilityType::BR_VOID,
+    MonsterAbilityType::BR_ABYSS,
+    MonsterAbilityType::BA_ACID,
+    MonsterAbilityType::BA_ELEC,
+    MonsterAbilityType::BA_FIRE,
+    MonsterAbilityType::BA_COLD,
+    MonsterAbilityType::BA_POIS,
+    MonsterAbilityType::BA_NETH,
+    MonsterAbilityType::BA_WATE,
+    MonsterAbilityType::BA_MANA,
+    MonsterAbilityType::BA_DARK,
+    MonsterAbilityType::BA_VOID,
+    MonsterAbilityType::BA_ABYSS,
+    MonsterAbilityType::BA_METEOR,
+    MonsterAbilityType::DRAIN_MANA,
+    MonsterAbilityType::MIND_BLAST,
+    MonsterAbilityType::BRAIN_SMASH,
+    MonsterAbilityType::CAUSE_1,
+    MonsterAbilityType::CAUSE_2,
+    MonsterAbilityType::CAUSE_3,
+    MonsterAbilityType::CAUSE_4,
+    MonsterAbilityType::BO_ACID,
+    MonsterAbilityType::BO_ELEC,
+    MonsterAbilityType::BO_FIRE,
+    MonsterAbilityType::BO_COLD,
+    MonsterAbilityType::BA_LITE,
+    MonsterAbilityType::BO_NETH,
+    MonsterAbilityType::BO_WATE,
+    MonsterAbilityType::BO_MANA,
+    MonsterAbilityType::BO_PLAS,
+    MonsterAbilityType::BO_ICEE,
+    MonsterAbilityType::BO_VOID,
+    MonsterAbilityType::BO_ABYSS,
+    MonsterAbilityType::BO_METEOR,
+    MonsterAbilityType::BO_LITE,
+    MonsterAbilityType::MISSILE,
+    MonsterAbilityType::SCARE,
+    MonsterAbilityType::BLIND,
+    MonsterAbilityType::CONF,
+    MonsterAbilityType::SLOW,
+    MonsterAbilityType::HOLD,
+    MonsterAbilityType::HAND_DOOM,
+    MonsterAbilityType::TELE_AWAY,
+    MonsterAbilityType::PSY_SPEAR,
+};
+}
 
 static int damage;
 
@@ -288,13 +363,19 @@ static int get_mane_power(PlayerType *player_ptr, int *sn, bool baigaesi)
  */
 static bool use_mane(PlayerType *player_ptr, MonsterAbilityType spell)
 {
-    DIRECTION dir;
     PLAYER_LEVEL plev = player_ptr->lev;
     BIT_FLAGS mode = (PM_ALLOW_GROUP | PM_FORCE_PET);
     BIT_FLAGS u_mode = 0L;
 
     if (randint1(50 + plev) < plev / 10) {
         u_mode = PM_ALLOW_UNIQUE;
+    }
+
+    int dir = 0;
+    if (AIMING_SPELLS.contains(spell)) {
+        if (!get_aim_dir(player_ptr, &dir)) {
+            return false;
+        }
     }
 
     /* spell code */
@@ -327,20 +408,12 @@ static bool use_mane(PlayerType *player_ptr, MonsterAbilityType spell)
     }
 
     case MonsterAbilityType::ROCKET:
-        if (!get_aim_dir(player_ptr, &dir)) {
-            return false;
-        } else {
-            msg_print(_("ロケットを発射した。", "You fire a rocket."));
-        }
+        msg_print(_("ロケットを発射した。", "You fire a rocket."));
         fire_rocket(player_ptr, AttributeType::ROCKET, dir, damage, 2);
         break;
 
     case MonsterAbilityType::SHOOT:
-        if (!get_aim_dir(player_ptr, &dir)) {
-            return false;
-        } else {
-            msg_print(_("矢を放った。", "You fire an arrow."));
-        }
+        msg_print(_("矢を放った。", "You fire an arrow."));
         fire_bolt(player_ptr, AttributeType::MONSTER_SHOOT, dir, damage);
         break;
 
@@ -354,573 +427,284 @@ static bool use_mane(PlayerType *player_ptr, MonsterAbilityType spell)
         break;
 
     case MonsterAbilityType::BR_ACID:
-        if (!get_aim_dir(player_ptr, &dir)) {
-            return false;
-        } else {
-            msg_print(_("酸のブレスを吐いた。", "You breathe acid."));
-        }
+        msg_print(_("酸のブレスを吐いた。", "You breathe acid."));
         fire_breath(player_ptr, AttributeType::ACID, dir, damage, (plev > 35 ? 3 : 2));
         break;
 
     case MonsterAbilityType::BR_ELEC:
-        if (!get_aim_dir(player_ptr, &dir)) {
-            return false;
-        } else {
-            msg_print(_("稲妻のブレスを吐いた。", "You breathe lightning."));
-        }
+        msg_print(_("稲妻のブレスを吐いた。", "You breathe lightning."));
         fire_breath(player_ptr, AttributeType::ELEC, dir, damage, (plev > 35 ? 3 : 2));
         break;
 
     case MonsterAbilityType::BR_FIRE:
-        if (!get_aim_dir(player_ptr, &dir)) {
-            return false;
-        } else {
-            msg_print(_("火炎のブレスを吐いた。", "You breathe fire."));
-        }
+        msg_print(_("火炎のブレスを吐いた。", "You breathe fire."));
         fire_breath(player_ptr, AttributeType::FIRE, dir, damage, (plev > 35 ? 3 : 2));
         break;
 
     case MonsterAbilityType::BR_COLD:
-        if (!get_aim_dir(player_ptr, &dir)) {
-            return false;
-        } else {
-            msg_print(_("冷気のブレスを吐いた。", "You breathe frost."));
-        }
+        msg_print(_("冷気のブレスを吐いた。", "You breathe frost."));
         fire_breath(player_ptr, AttributeType::COLD, dir, damage, (plev > 35 ? 3 : 2));
         break;
 
     case MonsterAbilityType::BR_POIS:
-        if (!get_aim_dir(player_ptr, &dir)) {
-            return false;
-        } else {
-            msg_print(_("ガスのブレスを吐いた。", "You breathe gas."));
-        }
+        msg_print(_("ガスのブレスを吐いた。", "You breathe gas."));
         fire_breath(player_ptr, AttributeType::POIS, dir, damage, (plev > 35 ? 3 : 2));
         break;
 
     case MonsterAbilityType::BR_NETH:
-        if (!get_aim_dir(player_ptr, &dir)) {
-            return false;
-        } else {
-            msg_print(_("地獄のブレスを吐いた。", "You breathe nether."));
-        }
+        msg_print(_("地獄のブレスを吐いた。", "You breathe nether."));
         fire_breath(player_ptr, AttributeType::NETHER, dir, damage, (plev > 35 ? 3 : 2));
         break;
 
     case MonsterAbilityType::BR_LITE:
-        if (!get_aim_dir(player_ptr, &dir)) {
-            return false;
-        } else {
-            msg_print(_("閃光のブレスを吐いた。", "You breathe light."));
-        }
+        msg_print(_("閃光のブレスを吐いた。", "You breathe light."));
         fire_breath(player_ptr, AttributeType::LITE, dir, damage, (plev > 35 ? 3 : 2));
         break;
 
     case MonsterAbilityType::BR_DARK:
-        if (!get_aim_dir(player_ptr, &dir)) {
-            return false;
-        } else {
-            msg_print(_("暗黒のブレスを吐いた。", "You breathe darkness."));
-        }
+        msg_print(_("暗黒のブレスを吐いた。", "You breathe darkness."));
         fire_breath(player_ptr, AttributeType::DARK, dir, damage, (plev > 35 ? 3 : 2));
         break;
 
     case MonsterAbilityType::BR_CONF:
-        if (!get_aim_dir(player_ptr, &dir)) {
-            return false;
-        } else {
-            msg_print(_("混乱のブレスを吐いた。", "You breathe confusion."));
-        }
+        msg_print(_("混乱のブレスを吐いた。", "You breathe confusion."));
         fire_breath(player_ptr, AttributeType::CONFUSION, dir, damage, (plev > 35 ? 3 : 2));
         break;
 
     case MonsterAbilityType::BR_SOUN:
-        if (!get_aim_dir(player_ptr, &dir)) {
-            return false;
-        } else {
-            msg_print(_("轟音のブレスを吐いた。", "You breathe sound."));
-        }
+        msg_print(_("轟音のブレスを吐いた。", "You breathe sound."));
         fire_breath(player_ptr, AttributeType::SOUND, dir, damage, (plev > 35 ? 3 : 2));
         break;
 
     case MonsterAbilityType::BR_CHAO:
-        if (!get_aim_dir(player_ptr, &dir)) {
-            return false;
-        } else {
-            msg_print(_("カオスのブレスを吐いた。", "You breathe chaos."));
-        }
+        msg_print(_("カオスのブレスを吐いた。", "You breathe chaos."));
         fire_breath(player_ptr, AttributeType::CHAOS, dir, damage, (plev > 35 ? 3 : 2));
         break;
 
     case MonsterAbilityType::BR_DISE:
-        if (!get_aim_dir(player_ptr, &dir)) {
-            return false;
-        } else {
-            msg_print(_("劣化のブレスを吐いた。", "You breathe disenchantment."));
-        }
+        msg_print(_("劣化のブレスを吐いた。", "You breathe disenchantment."));
         fire_breath(player_ptr, AttributeType::DISENCHANT, dir, damage, (plev > 35 ? 3 : 2));
         break;
 
     case MonsterAbilityType::BR_NEXU:
-        if (!get_aim_dir(player_ptr, &dir)) {
-            return false;
-        } else {
-            msg_print(_("因果混乱のブレスを吐いた。", "You breathe nexus."));
-        }
+        msg_print(_("因果混乱のブレスを吐いた。", "You breathe nexus."));
         fire_breath(player_ptr, AttributeType::NEXUS, dir, damage, (plev > 35 ? 3 : 2));
         break;
 
     case MonsterAbilityType::BR_TIME:
-        if (!get_aim_dir(player_ptr, &dir)) {
-            return false;
-        } else {
-            msg_print(_("時間逆転のブレスを吐いた。", "You breathe time."));
-        }
+        msg_print(_("時間逆転のブレスを吐いた。", "You breathe time."));
         fire_breath(player_ptr, AttributeType::TIME, dir, damage, (plev > 35 ? 3 : 2));
         break;
 
     case MonsterAbilityType::BR_INER:
-        if (!get_aim_dir(player_ptr, &dir)) {
-            return false;
-        } else {
-            msg_print(_("遅鈍のブレスを吐いた。", "You breathe inertia."));
-        }
+        msg_print(_("遅鈍のブレスを吐いた。", "You breathe inertia."));
         fire_breath(player_ptr, AttributeType::INERTIAL, dir, damage, (plev > 35 ? 3 : 2));
         break;
 
     case MonsterAbilityType::BR_GRAV:
-        if (!get_aim_dir(player_ptr, &dir)) {
-            return false;
-        } else {
-            msg_print(_("重力のブレスを吐いた。", "You breathe gravity."));
-        }
+        msg_print(_("重力のブレスを吐いた。", "You breathe gravity."));
         fire_breath(player_ptr, AttributeType::GRAVITY, dir, damage, (plev > 35 ? 3 : 2));
         break;
 
     case MonsterAbilityType::BR_SHAR:
-        if (!get_aim_dir(player_ptr, &dir)) {
-            return false;
-        } else {
-            msg_print(_("破片のブレスを吐いた。", "You breathe shards."));
-        }
+        msg_print(_("破片のブレスを吐いた。", "You breathe shards."));
         fire_breath(player_ptr, AttributeType::SHARDS, dir, damage, (plev > 35 ? 3 : 2));
         break;
 
     case MonsterAbilityType::BR_PLAS:
-        if (!get_aim_dir(player_ptr, &dir)) {
-            return false;
-        } else {
-            msg_print(_("プラズマのブレスを吐いた。", "You breathe plasma."));
-        }
+        msg_print(_("プラズマのブレスを吐いた。", "You breathe plasma."));
         fire_breath(player_ptr, AttributeType::PLASMA, dir, damage, (plev > 35 ? 3 : 2));
         break;
 
     case MonsterAbilityType::BR_FORC:
-        if (!get_aim_dir(player_ptr, &dir)) {
-            return false;
-        } else {
-            msg_print(_("フォースのブレスを吐いた。", "You breathe force."));
-        }
+        msg_print(_("フォースのブレスを吐いた。", "You breathe force."));
         fire_breath(player_ptr, AttributeType::FORCE, dir, damage, (plev > 35 ? 3 : 2));
         break;
 
     case MonsterAbilityType::BR_MANA:
-        if (!get_aim_dir(player_ptr, &dir)) {
-            return false;
-        } else {
-            msg_print(_("魔力のブレスを吐いた。", "You breathe mana."));
-        }
+        msg_print(_("魔力のブレスを吐いた。", "You breathe mana."));
         fire_breath(player_ptr, AttributeType::MANA, dir, damage, (plev > 35 ? 3 : 2));
         break;
 
     case MonsterAbilityType::BA_NUKE:
-        if (!get_aim_dir(player_ptr, &dir)) {
-            return false;
-        } else {
-            msg_print(_("放射能球を放った。", "You cast a ball of radiation."));
-        }
+        msg_print(_("放射能球を放った。", "You cast a ball of radiation."));
         fire_ball(player_ptr, AttributeType::NUKE, dir, damage, 2);
         break;
 
     case MonsterAbilityType::BR_NUKE:
-        if (!get_aim_dir(player_ptr, &dir)) {
-            return false;
-        } else {
-            msg_print(_("放射性廃棄物のブレスを吐いた。", "You breathe toxic waste."));
-        }
-
+        msg_print(_("放射性廃棄物のブレスを吐いた。", "You breathe toxic waste."));
         fire_breath(player_ptr, AttributeType::NUKE, dir, damage, (plev > 35 ? 3 : 2));
         break;
 
     case MonsterAbilityType::BA_CHAO:
-        if (!get_aim_dir(player_ptr, &dir)) {
-            return false;
-        } else {
-            msg_print(_("純ログルスを放った。", "You invoke a raw Logrus."));
-        }
-
+        msg_print(_("純ログルスを放った。", "You invoke a raw Logrus."));
         fire_ball(player_ptr, AttributeType::CHAOS, dir, damage, 4);
         break;
     case MonsterAbilityType::BR_DISI:
-        if (!get_aim_dir(player_ptr, &dir)) {
-            return false;
-        } else {
-            msg_print(_("分解のブレスを吐いた。", "You breathe disintegration."));
-        }
-
+        msg_print(_("分解のブレスを吐いた。", "You breathe disintegration."));
         fire_breath(player_ptr, AttributeType::DISINTEGRATE, dir, damage, (plev > 35 ? 3 : 2));
         break;
     case MonsterAbilityType::BR_VOID:
-        if (!get_aim_dir(player_ptr, &dir)) {
-            return false;
-        } else {
-            msg_print(_("虚無のブレスを吐いた。", "You breathe void."));
-        }
-
+        msg_print(_("虚無のブレスを吐いた。", "You breathe void."));
         fire_breath(player_ptr, AttributeType::VOID_MAGIC, dir, damage, (plev > 35 ? 3 : 2));
         break;
 
     case MonsterAbilityType::BR_ABYSS:
-        if (!get_aim_dir(player_ptr, &dir)) {
-            return false;
-        } else {
-            msg_print(_("深淵のブレスを吐いた。", "You breathe abyss."));
-        }
-
+        msg_print(_("深淵のブレスを吐いた。", "You breathe abyss."));
         fire_breath(player_ptr, AttributeType::ABYSS, dir, damage, (plev > 35 ? 3 : 2));
         break;
 
     case MonsterAbilityType::BA_ACID:
-        if (!get_aim_dir(player_ptr, &dir)) {
-            return false;
-        } else {
-            msg_print(_("アシッド・ボールの呪文を唱えた。", "You cast an acid ball."));
-        }
-
+        msg_print(_("アシッド・ボールの呪文を唱えた。", "You cast an acid ball."));
         fire_ball(player_ptr, AttributeType::ACID, dir, damage, 2);
         break;
     case MonsterAbilityType::BA_ELEC:
-        if (!get_aim_dir(player_ptr, &dir)) {
-            return false;
-        } else {
-            msg_print(_("サンダー・ボールの呪文を唱えた。", "You cast a lightning ball."));
-        }
-
+        msg_print(_("サンダー・ボールの呪文を唱えた。", "You cast a lightning ball."));
         fire_ball(player_ptr, AttributeType::ELEC, dir, damage, 2);
         break;
     case MonsterAbilityType::BA_FIRE:
-        if (!get_aim_dir(player_ptr, &dir)) {
-            return false;
-        } else {
-            msg_print(_("ファイア・ボールの呪文を唱えた。", "You cast a fire ball."));
-        }
-
+        msg_print(_("ファイア・ボールの呪文を唱えた。", "You cast a fire ball."));
         fire_ball(player_ptr, AttributeType::FIRE, dir, damage, 2);
         break;
     case MonsterAbilityType::BA_COLD:
-        if (!get_aim_dir(player_ptr, &dir)) {
-            return false;
-        } else {
-            msg_print(_("アイス・ボールの呪文を唱えた。", "You cast a frost ball."));
-        }
-
+        msg_print(_("アイス・ボールの呪文を唱えた。", "You cast a frost ball."));
         fire_ball(player_ptr, AttributeType::COLD, dir, damage, 2);
         break;
     case MonsterAbilityType::BA_POIS:
-        if (!get_aim_dir(player_ptr, &dir)) {
-            return false;
-        } else {
-            msg_print(_("悪臭雲の呪文を唱えた。", "You cast a stinking cloud."));
-        }
-
+        msg_print(_("悪臭雲の呪文を唱えた。", "You cast a stinking cloud."));
         fire_ball(player_ptr, AttributeType::POIS, dir, damage, 2);
         break;
     case MonsterAbilityType::BA_NETH:
-        if (!get_aim_dir(player_ptr, &dir)) {
-            return false;
-        } else {
-            msg_print(_("地獄球の呪文を唱えた。", "You cast a nether ball."));
-        }
-
+        msg_print(_("地獄球の呪文を唱えた。", "You cast a nether ball."));
         fire_ball(player_ptr, AttributeType::NETHER, dir, damage, 2);
         break;
     case MonsterAbilityType::BA_WATE:
-        if (!get_aim_dir(player_ptr, &dir)) {
-            return false;
-        } else {
-            msg_print(_("流れるような身振りをした。", "You gesture fluidly."));
-        }
-
+        msg_print(_("流れるような身振りをした。", "You gesture fluidly."));
         fire_ball(player_ptr, AttributeType::WATER, dir, damage, 4);
         break;
     case MonsterAbilityType::BA_MANA:
-        if (!get_aim_dir(player_ptr, &dir)) {
-            return false;
-        } else {
-            msg_print(_("魔力の嵐の呪文を念じた。", "You invoke a mana storm."));
-        }
-
+        msg_print(_("魔力の嵐の呪文を念じた。", "You invoke a mana storm."));
         fire_ball(player_ptr, AttributeType::MANA, dir, damage, 4);
         break;
     case MonsterAbilityType::BA_DARK:
-        if (!get_aim_dir(player_ptr, &dir)) {
-            return false;
-        } else {
-            msg_print(_("暗黒の嵐の呪文を念じた。", "You invoke a darkness storm."));
-        }
-
+        msg_print(_("暗黒の嵐の呪文を念じた。", "You invoke a darkness storm."));
         fire_ball(player_ptr, AttributeType::DARK, dir, damage, 4);
         break;
     case MonsterAbilityType::BA_VOID:
-        if (!get_aim_dir(player_ptr, &dir)) {
-            return false;
-        } else {
-            msg_print(_("虚無の嵐の呪文を念じた。", "You cast a void ball."));
-        }
-
+        msg_print(_("虚無の嵐の呪文を念じた。", "You cast a void ball."));
         fire_ball(player_ptr, AttributeType::VOID_MAGIC, dir, damage, 4);
         break;
     case MonsterAbilityType::BA_ABYSS:
-        if (!get_aim_dir(player_ptr, &dir)) {
-            return false;
-        } else {
-            msg_print(_("深淵の嵐の呪文を念じた。", "You cast a abyss ball."));
-        }
-
+        msg_print(_("深淵の嵐の呪文を念じた。", "You cast a abyss ball."));
         fire_ball(player_ptr, AttributeType::ABYSS, dir, damage, 4);
         break;
     case MonsterAbilityType::BA_METEOR:
-        if (!get_aim_dir(player_ptr, &dir)) {
-            return false;
-        } else {
-            msg_print(_("メテオスウォームの呪文を念じた。", "You cast a meteor swarm."));
-        }
-
+        msg_print(_("メテオスウォームの呪文を念じた。", "You cast a meteor swarm."));
         fire_ball(player_ptr, AttributeType::METEOR, dir, damage, 4);
         break;
     case MonsterAbilityType::DRAIN_MANA:
-        if (!get_aim_dir(player_ptr, &dir)) {
-            return false;
-        }
         fire_ball_hide(player_ptr, AttributeType::DRAIN_MANA, dir, randint1(plev * 3) + plev, 0);
         break;
     case MonsterAbilityType::MIND_BLAST:
-        if (!get_aim_dir(player_ptr, &dir)) {
-            return false;
-        }
         fire_ball_hide(player_ptr, AttributeType::MIND_BLAST, dir, damage, 0);
         break;
     case MonsterAbilityType::BRAIN_SMASH:
-        if (!get_aim_dir(player_ptr, &dir)) {
-            return false;
-        }
         fire_ball_hide(player_ptr, AttributeType::BRAIN_SMASH, dir, damage, 0);
         break;
     case MonsterAbilityType::CAUSE_1:
-        if (!get_aim_dir(player_ptr, &dir)) {
-            return false;
-        }
         fire_ball_hide(player_ptr, AttributeType::CAUSE_1, dir, damage, 0);
         break;
     case MonsterAbilityType::CAUSE_2:
-        if (!get_aim_dir(player_ptr, &dir)) {
-            return false;
-        }
         fire_ball_hide(player_ptr, AttributeType::CAUSE_2, dir, damage, 0);
         break;
     case MonsterAbilityType::CAUSE_3:
-        if (!get_aim_dir(player_ptr, &dir)) {
-            return false;
-        }
         fire_ball_hide(player_ptr, AttributeType::CAUSE_3, dir, damage, 0);
         break;
     case MonsterAbilityType::CAUSE_4:
-        if (!get_aim_dir(player_ptr, &dir)) {
-            return false;
-        }
         fire_ball_hide(player_ptr, AttributeType::CAUSE_4, dir, damage, 0);
         break;
     case MonsterAbilityType::BO_ACID:
-        if (!get_aim_dir(player_ptr, &dir)) {
-            return false;
-        } else {
-            msg_print(_("アシッド・ボルトの呪文を唱えた。", "You cast an acid bolt."));
-        }
-
+        msg_print(_("アシッド・ボルトの呪文を唱えた。", "You cast an acid bolt."));
         fire_bolt(player_ptr, AttributeType::ACID, dir, damage);
         break;
     case MonsterAbilityType::BO_ELEC:
-        if (!get_aim_dir(player_ptr, &dir)) {
-            return false;
-        } else {
-            msg_print(_("サンダー・ボルトの呪文を唱えた。", "You cast a lightning bolt."));
-        }
-
+        msg_print(_("サンダー・ボルトの呪文を唱えた。", "You cast a lightning bolt."));
         fire_bolt(player_ptr, AttributeType::ELEC, dir, damage);
         break;
     case MonsterAbilityType::BO_FIRE:
-        if (!get_aim_dir(player_ptr, &dir)) {
-            return false;
-        } else {
-            msg_print(_("ファイア・ボルトの呪文を唱えた。", "You cast a fire bolt."));
-        }
-
+        msg_print(_("ファイア・ボルトの呪文を唱えた。", "You cast a fire bolt."));
         fire_bolt(player_ptr, AttributeType::FIRE, dir, damage);
         break;
     case MonsterAbilityType::BO_COLD:
-        if (!get_aim_dir(player_ptr, &dir)) {
-            return false;
-        } else {
-            msg_print(_("アイス・ボルトの呪文を唱えた。", "You cast a frost bolt."));
-        }
-
+        msg_print(_("アイス・ボルトの呪文を唱えた。", "You cast a frost bolt."));
         fire_bolt(player_ptr, AttributeType::COLD, dir, damage);
         break;
     case MonsterAbilityType::BA_LITE:
-        if (!get_aim_dir(player_ptr, &dir)) {
-            return false;
-        } else {
-            msg_print(_("スターバーストの呪文を念じた。", "You invoke a starburst."));
-        }
-
+        msg_print(_("スターバーストの呪文を念じた。", "You invoke a starburst."));
         fire_ball(player_ptr, AttributeType::LITE, dir, damage, 4);
         break;
     case MonsterAbilityType::BO_NETH:
-        if (!get_aim_dir(player_ptr, &dir)) {
-            return false;
-        } else {
-            msg_print(_("地獄の矢の呪文を唱えた。", "You cast a nether bolt."));
-        }
-
+        msg_print(_("地獄の矢の呪文を唱えた。", "You cast a nether bolt."));
         fire_bolt(player_ptr, AttributeType::NETHER, dir, damage);
         break;
     case MonsterAbilityType::BO_WATE:
-        if (!get_aim_dir(player_ptr, &dir)) {
-            return false;
-        } else {
-            msg_print(_("ウォーター・ボルトの呪文を唱えた。", "You cast a water bolt."));
-        }
-
+        msg_print(_("ウォーター・ボルトの呪文を唱えた。", "You cast a water bolt."));
         fire_bolt(player_ptr, AttributeType::WATER, dir, damage);
         break;
     case MonsterAbilityType::BO_MANA:
-        if (!get_aim_dir(player_ptr, &dir)) {
-            return false;
-        } else {
-            msg_print(_("魔力の矢の呪文を唱えた。", "You cast a mana bolt."));
-        }
-
+        msg_print(_("魔力の矢の呪文を唱えた。", "You cast a mana bolt."));
         fire_bolt(player_ptr, AttributeType::MANA, dir, damage);
         break;
     case MonsterAbilityType::BO_PLAS:
-        if (!get_aim_dir(player_ptr, &dir)) {
-            return false;
-        } else {
-            msg_print(_("プラズマ・ボルトの呪文を唱えた。", "You cast a plasma bolt."));
-        }
-
+        msg_print(_("プラズマ・ボルトの呪文を唱えた。", "You cast a plasma bolt."));
         fire_bolt(player_ptr, AttributeType::PLASMA, dir, damage);
         break;
     case MonsterAbilityType::BO_ICEE:
-        if (!get_aim_dir(player_ptr, &dir)) {
-            return false;
-        } else {
-            msg_print(_("極寒の矢の呪文を唱えた。", "You cast a ice bolt."));
-        }
-
+        msg_print(_("極寒の矢の呪文を唱えた。", "You cast a ice bolt."));
         fire_bolt(player_ptr, AttributeType::ICE, dir, damage);
         break;
     case MonsterAbilityType::BO_VOID:
-        if (!get_aim_dir(player_ptr, &dir)) {
-            return false;
-        } else {
-            msg_print(_("虚無の矢の呪文を唱えた。", "You cast a void bolt."));
-        }
-
+        msg_print(_("虚無の矢の呪文を唱えた。", "You cast a void bolt."));
         fire_bolt(player_ptr, AttributeType::VOID_MAGIC, dir, damage);
         break;
     case MonsterAbilityType::BO_ABYSS:
-        if (!get_aim_dir(player_ptr, &dir)) {
-            return false;
-        } else {
-            msg_print(_("深淵の矢の呪文を唱えた。", "You cast a abyss bolt."));
-        }
-
+        msg_print(_("深淵の矢の呪文を唱えた。", "You cast a abyss bolt."));
         fire_bolt(player_ptr, AttributeType::ABYSS, dir, damage);
         break;
     case MonsterAbilityType::BO_METEOR:
-        if (!get_aim_dir(player_ptr, &dir)) {
-            return false;
-        } else {
-            msg_print(_("メテオストライクの呪文を唱えた。", "You cast a meteor strike."));
-        }
-
+        msg_print(_("メテオストライクの呪文を唱えた。", "You cast a meteor strike."));
         fire_bolt(player_ptr, AttributeType::METEOR, dir, damage);
         break;
     case MonsterAbilityType::BO_LITE:
-        if (!get_aim_dir(player_ptr, &dir)) {
-            return false;
-        } else {
-            msg_print(_("スターライトアローの呪文を唱えた。", "You cast a starlight arrow."));
-        }
-
+        msg_print(_("スターライトアローの呪文を唱えた。", "You cast a starlight arrow."));
         fire_bolt(player_ptr, AttributeType::LITE, dir, damage);
         break;
     case MonsterAbilityType::MISSILE:
-        if (!get_aim_dir(player_ptr, &dir)) {
-            return false;
-        } else {
-            msg_print(_("マジック・ミサイルの呪文を唱えた。", "You cast a magic missile."));
-        }
-
+        msg_print(_("マジック・ミサイルの呪文を唱えた。", "You cast a magic missile."));
         fire_bolt(player_ptr, AttributeType::MISSILE, dir, damage);
         break;
     case MonsterAbilityType::SCARE:
-        if (!get_aim_dir(player_ptr, &dir)) {
-            return false;
-        } else {
-            msg_print(_("恐ろしげな幻覚を作り出した。", "You cast a fearful illusion."));
-        }
-
+        msg_print(_("恐ろしげな幻覚を作り出した。", "You cast a fearful illusion."));
         fear_monster(player_ptr, dir, plev + 10);
         break;
     case MonsterAbilityType::BLIND:
-        if (!get_aim_dir(player_ptr, &dir)) {
-            return false;
-        }
         confuse_monster(player_ptr, dir, plev * 2);
         break;
     case MonsterAbilityType::CONF:
-        if (!get_aim_dir(player_ptr, &dir)) {
-            return false;
-        } else {
-            msg_print(_("誘惑的な幻覚をつくり出した。", "You cast a mesmerizing illusion."));
-        }
-
+        msg_print(_("誘惑的な幻覚をつくり出した。", "You cast a mesmerizing illusion."));
         confuse_monster(player_ptr, dir, plev * 2);
         break;
     case MonsterAbilityType::SLOW:
-        if (!get_aim_dir(player_ptr, &dir)) {
-            return false;
-        }
         slow_monster(player_ptr, dir, plev);
         break;
     case MonsterAbilityType::HOLD:
-        if (!get_aim_dir(player_ptr, &dir)) {
-            return false;
-        }
         sleep_monster(player_ptr, dir, plev);
         break;
     case MonsterAbilityType::HASTE:
         (void)set_acceleration(player_ptr, randint1(20 + plev) + plev, false);
         break;
     case MonsterAbilityType::HAND_DOOM: {
-        if (!get_aim_dir(player_ptr, &dir)) {
-            return false;
-        } else {
-            msg_print(_("<破滅の手>を放った！", "You invoke the Hand of Doom!"));
-        }
-
+        msg_print(_("<破滅の手>を放った！", "You invoke the Hand of Doom!"));
         fire_ball_hide(player_ptr, AttributeType::HAND_DOOM, dir, 200, 0);
         break;
     }
@@ -988,10 +772,6 @@ static bool use_mane(PlayerType *player_ptr, MonsterAbilityType spell)
         break;
     }
     case MonsterAbilityType::TELE_AWAY:
-        if (!get_aim_dir(player_ptr, &dir)) {
-            return false;
-        }
-
         (void)fire_beam(player_ptr, AttributeType::AWAY_ALL, dir, plev);
         break;
 
@@ -1000,11 +780,7 @@ static bool use_mane(PlayerType *player_ptr, MonsterAbilityType spell)
         break;
 
     case MonsterAbilityType::PSY_SPEAR:
-        if (!get_aim_dir(player_ptr, &dir)) {
-            return false;
-        } else {
-            msg_print(_("光の剣を放った。", "You throw a psycho-spear."));
-        }
+        msg_print(_("光の剣を放った。", "You throw a psycho-spear."));
         (void)fire_beam(player_ptr, AttributeType::PSY_SPEAR, dir, damage);
         break;
 


### PR DESCRIPTION
switch case の分岐内でそれぞれ get_aim_dir() で行われている
ターゲッティング処理を削除し、ターゲッティングが必要な魔法の場合は
分岐前にまとめてターゲッティング処理を行うように修正する。