### PR TITLE
変愚「[Fix] 青魔道士でキャラクタダンプ出力時にクラッシュ #4995」のマージ

### DIFF
--- a/src/mspell/monster-power-table.cpp
+++ b/src/mspell/monster-power-table.cpp
@@ -188,6 +188,8 @@ const std::map<MonsterAbilityType, concptr> monster_powers_short = {
     { MonsterAbilityType::BO_ICEE, _("極寒", "Ice") },
     { MonsterAbilityType::BO_VOID, _("ヴォイド", "Void") },
     { MonsterAbilityType::BO_ABYSS, _("アビス", "Abyss") },
+    { MonsterAbilityType::BO_METEOR, { _("メテオストライク", "meteor strike") } },
+    { MonsterAbilityType::BO_LITE, { _("スターライトアロー", "starlight arrow") } },
     { MonsterAbilityType::MISSILE, _("マジックミサイル", "Magic missile") },
     { MonsterAbilityType::SCARE, _("恐慌", "Scare") },
     { MonsterAbilityType::BLIND, _("盲目", "Blind") },


### PR DESCRIPTION
出力する青魔法のテーブルが不足しているため、「メテオストライク」
「スターライトアロー」を覚えているとクラッシュする。
テーブルにこれらの項目を追加する。