### PR TITLE
変愚「[Fix] トラベルコマンドが効かない #5003」のマージ

### DIFF
--- a/src/cmd-action/cmd-travel.cpp
+++ b/src/cmd-action/cmd-travel.cpp
@@ -38,7 +38,7 @@ void do_cmd_travel(PlayerType *player_ptr)
         return;
     }
 
-    if (Travel::can_travel_to(*player_ptr->current_floor_ptr, *pos)) {
+    if (!Travel::can_travel_to(*player_ptr->current_floor_ptr, *pos)) {
         msg_print(_("そこには行くことができません！", "You cannot travel there!"));
         return;
     }


### PR DESCRIPTION
d6d25a06 で真偽反転により発生したエンバグを修正する。