### PR TITLE
変愚「[Fix] LOSでブレスがヒットしない #5049」のマージ

### DIFF
--- a/src/spell/range-calc.cpp
+++ b/src/spell/range-calc.cpp
@@ -252,7 +252,7 @@ std::vector<std::pair<int, Pos2D>> breath_shape(PlayerType *player_ptr, const Pr
                     if (Grid::calc_distance(pos_breath, pos) != cdis) {
                         continue;
                     }
-                    if (is_prevent_blast(player_ptr, pos_source, pos, typ)) {
+                    if (is_prevent_blast(player_ptr, pos_breath, pos, typ)) {
                         continue;
                     }
 


### PR DESCRIPTION
5b4cc60 の変更で引数に pos_breath を渡すべきところで pos_source を渡して いるのが原因。
正しい引数を渡すよう修正する。