### PR TITLE
変愚「[Fix] ザックが空の状態でアイテムを拾うとクラッシュする #5066」のマージ

### DIFF
--- a/src/inventory/inventory-object.cpp
+++ b/src/inventory/inventory-object.cpp
@@ -303,7 +303,7 @@ int16_t store_item_to_inventory(PlayerType *player_ptr, ItemEntity *o_ptr)
     }
 
     i = j;
-    if (i < INVEN_PACK) {
+    if (i < INVEN_PACK && n >= 0) {
         for (j = 0; j < INVEN_PACK; j++) {
             if (object_sort_comp(player_ptr, *o_ptr, *player_ptr->inventory[j])) {
                 break;


### PR DESCRIPTION
ザックが空の状態（n == -1）でアイテムを拾うと
std::rotate(begin + i, begin + n + 1, begin + n + 2); が実行されるが、 begin + n の段階でイテレータが有効な範囲外を指すため、STLデバッグビルドが
有効だとイテレータの範囲チェックにより例外が発生しクラッシュする。
そもそもザックが空の場合は挿入するスロットを空ける必要がないので、
n >= 0 の時のみ処理を実行するよう修正する。