### PR TITLE
変愚「[Fix] モンスターの逃走処理 #5080」のマージ

### DIFF
--- a/src/monster-floor/monster-sweep-grid.cpp
+++ b/src/monster-floor/monster-sweep-grid.cpp
@@ -117,7 +117,7 @@ public:
         const auto no_flow = monster.mflag2.has(MonsterConstantFlagType::NOFLOW) && (floor.get_grid(m_pos).get_cost(monrace.get_grid_flow_type()) > 2);
 
         // 単に反対側に逃げる(あまり賢くない方法)場合の移動先
-        const auto pos_run_away_simple = m_pos + (pos_move - m_pos);
+        const auto pos_run_away_simple = m_pos + (m_pos - pos_move);
         if (monster.is_pet() || no_flow) {
             return pos_run_away_simple;
         }


### PR DESCRIPTION
モンスターの移動ルーチンで単にプレイヤーから離れようとする時の計算式が
誤っておりプレイヤーに近づいてしまうようになっている。
ペットコマンドで「少し離れていろ」「離れていろ」を選択した際にも
このルーチンが使用されるので、結果としてこれらの指示を行うとペットが
近づいてきてしまう。
ただしい計算式に修正し、プレイヤーから離れようとするようにする。