### PR TITLE
変愚「[Fix] 薬を投げた時にクラッシュする #5099」のマージ

### DIFF
--- a/src/cmd-item/cmd-throw.cpp
+++ b/src/cmd-item/cmd-throw.cpp
@@ -72,11 +72,11 @@ bool ThrowCommand::do_cmd_throw(int mult, bool boomerang, OBJECT_IDX shuriken)
     ote.prev_y = ote.y;
     ote.prev_x = ote.x;
     ote.exe_throw();
-    if (ote.hit_body) {
+    if (ote.has_hit_monster()) {
         torch_lost_fuel(ote.q_ptr);
     }
 
-    ote.corruption_possibility = ote.hit_body ? breakage_chance(this->player_ptr, ote.q_ptr, pc.equals(PlayerClassType::ARCHER), 0) : 0;
+    ote.corruption_possibility = ote.has_hit_monster() ? breakage_chance(this->player_ptr, ote.q_ptr, pc.equals(PlayerClassType::ARCHER), 0) : 0;
     ote.display_figurine_throw();
     ote.display_potion_throw();
     ote.check_boomerang_throw();

--- a/src/object-use/throw-execution.h
+++ b/src/object-use/throw-execution.h
@@ -14,6 +14,16 @@ class Grid;
 class MonsterEntity;
 class ItemEntity;
 class PlayerType;
+
+class ObjectThrowHitMonster {
+public:
+    ObjectThrowHitMonster(PlayerType *player_ptr, POSITION y, POSITION x);
+
+    MONSTER_IDX m_idx{};
+    MonsterEntity *m_ptr{};
+    std::string m_name{};
+};
+
 class ObjectThrowEntity {
 public:
     ObjectThrowEntity() = default;
@@ -28,7 +38,6 @@ public:
     POSITION prev_y{};
     POSITION prev_x{};
     bool equiped_item = false;
-    bool hit_body = false;
     PERCENTAGE corruption_possibility{};
 
     bool check_can_throw();
@@ -43,6 +52,7 @@ public:
     void check_boomerang_throw();
     void process_boomerang_back();
     void drop_thrown_item();
+    bool has_hit_monster() const;
 
 private:
     PlayerType *player_ptr;
@@ -58,7 +68,6 @@ private:
     int tdam{};
     int tdis{};
     int cur_dis{};
-    int visible{};
     ItemEntity *o_ptr{};
     bool hit_wall = false;
     bool return_when_thrown = false;
@@ -66,12 +75,10 @@ private:
     TrFlags obj_flags{};
     bool come_back = false;
     bool do_drop = true;
-    Grid *g_ptr{};
-    MonsterEntity *m_ptr{};
-    std::string m_name{};
     int back_chance{};
     std::string o2_name{};
     bool super_boomerang{};
+    std::optional<ObjectThrowHitMonster> hit_monster{};
 
     bool check_what_throw();
     bool check_throw_boomerang();


### PR DESCRIPTION
薬を投げて敵に当たらなかった場合に、敵に当たった時の情報を格納しておく
ポインタにアクセスしてしまいヌルポインタアクセスが発生している。
修正とともに敵に当たった時の情報をObjectThrowHitBodyクラスにまとめて
扱うようにする。