### PR TITLE
変愚「[Fix] 分解のブレスが指定位置に飛んでいかない #5109」のマージ

### DIFF
--- a/src/system/grid-type-definition.cpp
+++ b/src/system/grid-type-definition.cpp
@@ -244,7 +244,7 @@ bool Grid::can_block_disintegration() const
     const auto can_reach = this->has(TerrainCharacteristics::PROJECTION);
     auto can_disintegrate = this->has(TerrainCharacteristics::HURT_DISI);
     can_disintegrate &= !this->has(TerrainCharacteristics::PERMANENT);
-    return !can_reach || !can_disintegrate;
+    return !can_reach && !can_disintegrate;
 }
 
 bool Grid::can_generate_monster() const


### PR DESCRIPTION
fix #5108
分解属性攻撃の経路判定式が誤っている。