### PR TITLE
変愚「[Refactor] モンスターの反射時メッセージを外部読込に変更する #5126」のマージ

### DIFF
--- a/lib/edit/MonraceDefinitions.jsonc
+++ b/lib/edit/MonraceDefinitions.jsonc
@@ -49719,33 +49719,7 @@
             "ROCKET"
         ],
         "probability": "1_IN_4"
-    },
-      "message": [
-        {
-          "action": "WALK_CLOSERANGE",
-          "chance": 20,
-          "message": {
-            "ja": "近くで重厚な足音が聞こえた。",
-            "en": "You hear heavy steps nearby."
-          }
-        },
-        {
-          "action": "WALK_MIDDLERANGE",
-          "chance": 20,
-          "message": {
-            "ja": "重厚な足音が聞こえた。",
-            "en": "You hear heavy steps."
-          }
-        },
-        {
-          "action": "WALK_LONGRANGE",
-          "chance": 40,
-          "message": {
-            "ja": "遠くで重厚な足音が聞こえた。",
-            "en": "You hear heavy steps in the distance."
-          }
-        }
-      ]
+    }
 },
 {
     "id": 817,

--- a/lib/edit/MonsterMessages.jsonc
+++ b/lib/edit/MonsterMessages.jsonc
@@ -8314,6 +8314,18 @@
                             "crept up beside you."
                         ]
                     }
+                },
+                {
+                    "action": "MESSAGE_REFLECT",
+                    "chance": 1,
+                    "message": {
+                        "ja": [
+                            "攻撃は跳ね返った！"
+                        ],
+                        "en": [
+                            "The attack bounces!"
+                        ]
+                    }
                 }
             ]
         }

--- a/schema/MonraceDefinitions.schema.json
+++ b/schema/MonraceDefinitions.schema.json
@@ -716,7 +716,8 @@
                                         "WALK_CLOSERANGE",
                                         "WALK_MIDDLERANGE",
                                         "WALK_LONGRANGE",
-                                        "MESSAGE_STALKER"
+                                        "MESSAGE_STALKER",
+                                        "MESSAGE_REFLECT"
                                     ]
                                 },
                                 "chance": {

--- a/schema/MonsterMessages.schema.json
+++ b/schema/MonsterMessages.schema.json
@@ -54,7 +54,8 @@
                                     "WALK_CLOSERANGE",
                                     "WALK_MIDDLERANGE",
                                     "WALK_LONGRANGE",
-                                    "MESSAGE_STALKER"
+                                    "MESSAGE_STALKER",
+                                    "MESSAGE_REFLECT"
                                 ]
                             },
                             "chance": {

--- a/src/effect/effect-processor.cpp
+++ b/src/effect/effect-processor.cpp
@@ -290,12 +290,11 @@ ProjectResult project(PlayerType *player_ptr, const MONSTER_IDX src_idx, POSITIO
 
                     if (is_seen(player_ptr, monster)) {
                         sound(SoundKind::REFLECT);
-                        if ((monster.r_idx == MonraceId::KENSHIROU) || (monster.r_idx == MonraceId::RAOU)) {
-                            msg_print(_("「北斗神拳奥義・二指真空把！」", "The attack bounces!"));
-                        } else if (monster.r_idx == MonraceId::DIO) {
-                            msg_print(_("ディオ・ブランドーは指一本で攻撃を弾き返した！", "The attack bounces!"));
-                        } else {
-                            msg_print(_("攻撃は跳ね返った！", "The attack bounces!"));
+                        const auto reflect_message = monrace.get_message(MonsterMessageType::MESSAGE_REFLECT);
+                        if (reflect_message) {
+                            if (one_in_(reflect_message->get_message_chance())) {
+                                msg_print(reflect_message->get_message());
+                            }
                         }
                     } else if (!is_monster(src_idx)) {
                         sound(SoundKind::REFLECT);

--- a/src/info-reader/race-info-tokens-table.cpp
+++ b/src/info-reader/race-info-tokens-table.cpp
@@ -487,6 +487,7 @@ const std::unordered_map<std::string_view, MonsterMessageType> r_info_message_fl
     { "WALK_MIDDLERANGE", MonsterMessageType::WALK_MIDDLERANGE },
     { "WALK_LONGRANGE", MonsterMessageType::WALK_LONGRANGE },
     { "MESSAGE_STALKER", MonsterMessageType::MESSAGE_STALKER },
+    { "MESSAGE_REFLECT", MonsterMessageType::MESSAGE_REFLECT },
 };
 
 const std::unordered_map<std::string_view, MonsterBrightnessType> r_info_brightness_flags = {

--- a/src/monster-race/race-speak-flags.h
+++ b/src/monster-race/race-speak-flags.h
@@ -21,5 +21,6 @@ enum class MonsterMessageType {
     WALK_MIDDLERANGE = 7,
     WALK_LONGRANGE = 8,
     MESSAGE_STALKER = 9,
+    MESSAGE_REFLECT = 10,
     MAX
 };


### PR DESCRIPTION
馬鹿馬鹿ではjsonc側の更新は保留。

モンスターが攻撃を反射したときのメッセージを外部読込可能とする。
既存の動作は変更しない。