### PR TITLE
変愚「[Refactor] MonsterMessage::get_message_chance()を廃止 #5129」のマージ

### DIFF
--- a/src/effect/effect-processor.cpp
+++ b/src/effect/effect-processor.cpp
@@ -292,9 +292,7 @@ ProjectResult project(PlayerType *player_ptr, const MONSTER_IDX src_idx, POSITIO
                         sound(SoundKind::REFLECT);
                         const auto reflect_message = monrace.get_message(MonsterMessageType::MESSAGE_REFLECT);
                         if (reflect_message) {
-                            if (one_in_(reflect_message->get_message_chance())) {
-                                msg_print(reflect_message->get_message());
-                            }
+                            msg_print(*reflect_message);
                         }
                     } else if (!is_monster(src_idx)) {
                         sound(SoundKind::REFLECT);

--- a/src/monster-floor/monster-move.cpp
+++ b/src/monster-floor/monster-move.cpp
@@ -539,14 +539,12 @@ static std::optional<MonsterMessageType> get_speak_type(const MonsterEntity &mon
  * @param player_ptr プレイヤーへの参照ポインタ
  * @param message 対応するメッセージ
  */
-void process_sound(PlayerType *player_ptr, const std::string &message, const int chance)
+void process_sound(PlayerType *player_ptr, std::string_view message)
 {
-    if (one_in_(chance)) {
-        if (disturb_minor) {
-            disturb(player_ptr, false, false);
-        }
-        msg_print(message);
+    if (disturb_minor) {
+        disturb(player_ptr, false, false);
     }
+    msg_print(message);
 }
 
 /*!
@@ -572,23 +570,23 @@ void process_speak_sound(PlayerType *player_ptr, MONSTER_IDX m_idx, POSITION oy,
         if (!monster.ml && (monster.cdis <= MAX_PLAYER_SIGHT / 2)) {
             const auto message = monrace.get_message(MonsterMessageType::WALK_CLOSERANGE);
             if (message) {
-                process_sound(player_ptr, message->get_message(), message->get_message_chance());
-                return;
+                process_sound(player_ptr, *message);
             }
+            return;
         }
         if (!monster.ml && (monster.cdis <= MAX_PLAYER_SIGHT)) {
             const auto message = monrace.get_message(MonsterMessageType::WALK_MIDDLERANGE);
             if (message) {
-                process_sound(player_ptr, message->get_message(), message->get_message_chance());
-                return;
+                process_sound(player_ptr, *message);
             }
+            return;
         }
         if (!monster.ml && (monster.cdis <= MAX_PLAYER_SIGHT * 2)) {
             const auto message = monrace.get_message(MonsterMessageType::WALK_LONGRANGE);
             if (message) {
-                process_sound(player_ptr, message->get_message(), message->get_message_chance());
-                return;
+                process_sound(player_ptr, *message);
             }
+            return;
         }
     }
 
@@ -609,9 +607,6 @@ void process_speak_sound(PlayerType *player_ptr, MONSTER_IDX m_idx, POSITION oy,
 
     const auto monmessage = monrace.get_message(*message_type);
     if (monmessage) {
-        if (!one_in_(monmessage->get_message_chance())) {
-            return;
-        }
-        msg_format(_("%s^%s", "%s^ %s"), m_name.data(), monmessage->get_message().data());
+        msg_format(_("%s^%s", "%s^ %s"), m_name.data(), monmessage->data());
     }
 }

--- a/src/monster/monster-damage.cpp
+++ b/src/monster/monster-damage.cpp
@@ -256,9 +256,7 @@ void MonsterDamageProcessor::dying_scream(std::string_view m_name)
 
     const auto death_message = r_ref.get_message(MonsterMessageType::SPEAK_DEATH);
     if (death_message) {
-        if (one_in_(death_message->get_message_chance())) {
-            msg_format("%s^ %s", m_name.data(), death_message->get_message().data());
-        }
+        msg_format("%s^ %s", m_name.data(), death_message->data());
     }
 
 #ifdef WORLD_SCORE

--- a/src/monster/monster-processor.cpp
+++ b/src/monster/monster-processor.cpp
@@ -986,7 +986,7 @@ bool process_stalking(PlayerType *player_ptr, MONSTER_IDX m_idx)
     if (see_monster(player_ptr, m_idx)) {
         const auto message_stalker = monrace.get_message(MonsterMessageType::MESSAGE_STALKER);
         if (message_stalker) {
-            msg_format(_("%s^%s", "%s^ %s"), m_name.data(), message_stalker->get_message().data());
+            msg_format(_("%s^%s", "%s^ %s"), m_name.data(), message_stalker->data());
         }
     }
 

--- a/src/system/monrace/monrace-definition.cpp
+++ b/src/system/monrace/monrace-definition.cpp
@@ -330,14 +330,9 @@ bool MonraceDefinition::has_reinforce() const
     return it != end;
 }
 
-tl::optional<const MonsterMessage &> MonraceDefinition::get_message(const MonsterMessageType message_type) const
+std::optional<std::string_view> MonraceDefinition::get_message(const MonsterMessageType message_type) const
 {
-    auto message = MonraceMessageList::get_instance().get_message((int)this->idx, message_type);
-
-    if (message) {
-        return message;
-    }
-    return tl::nullopt;
+    return MonraceMessageList::get_instance().get_message((int)this->idx, message_type);
 }
 
 const std::vector<DropArtifact> &MonraceDefinition::get_drop_artifacts() const

--- a/src/system/monrace/monrace-definition.h
+++ b/src/system/monrace/monrace-definition.h
@@ -24,9 +24,9 @@
 #include "util/dice.h"
 #include "util/flag-group.h"
 #include "view/display-symbol.h"
+#include <optional>
 #include <string>
 #include <string_view>
-#include <tl/optional.hpp>
 #include <vector>
 
 /*! モンスターが1ターンに攻撃する最大回数 (射撃を含む) / The maximum number of times a monster can attack in a turn (including SHOOT) */
@@ -195,7 +195,7 @@ public:
     int calc_capture_value() const;
     std::string build_eldritch_horror_message(std::string_view description) const;
     bool has_reinforce() const;
-    tl::optional<const MonsterMessage &> get_message(const MonsterMessageType message_type) const;
+    std::optional<std::string_view> get_message(const MonsterMessageType message_type) const;
     const std::vector<DropArtifact> &get_drop_artifacts() const;
     const std::vector<Reinforce> &get_reinforces() const;
     bool can_generate() const;
@@ -243,7 +243,6 @@ public:
 
     std::optional<std::string> probe_lore();
     void make_lore_treasure(int num_item, int num_drop);
-    void set_message(MonsterMessageType message_type, int chance, std::string message);
     void emplace_drop_artifact(FixedArtifactId fa_id, int percentage);
     void emplace_reinforce(MonraceId monrace_id, const Dice &dice);
     std::vector<DropArtifact> drop_artifacts; //!< 特定アーティファクトドロップリスト

--- a/src/system/monrace/monrace-message.cpp
+++ b/src/system/monrace/monrace-message.cpp
@@ -1,6 +1,8 @@
 #include "system/monrace/monrace-message.h"
 #include "term/z-rand.h"
 #include <optional>
+#include <string>
+#include <string_view>
 #include <vector>
 
 MonsterMessage::MonsterMessage(int chance, std::string_view message)
@@ -9,13 +11,14 @@ MonsterMessage::MonsterMessage(int chance, std::string_view message)
 {
 }
 
-int MonsterMessage::get_message_chance() const
+std::optional<std::string_view> MonsterMessage::get_message() const
 {
-    return this->chance;
-}
-
-const std::string &MonsterMessage::get_message() const
-{
+    if (this->chance < 1) {
+        return std::nullopt;
+    }
+    if (!one_in_(this->chance)) {
+        return std::nullopt;
+    }
     return this->message;
 }
 
@@ -24,13 +27,13 @@ void MonsterMessageList::emplace(const int chance, std::string_view message_str)
     this->messages.emplace_back(chance, message_str);
 }
 
-tl::optional<const MonsterMessage &> MonsterMessageList::get_message() const
+std::optional<std::string_view> MonsterMessageList::get_message() const
 {
     if (this->messages.empty()) {
-        return tl::nullopt;
+        return std::nullopt;
     }
 
-    return rand_choice(this->messages);
+    return rand_choice(this->messages).get_message();
 }
 
 void MonraceMessage::emplace(const MonsterMessageType message_type, const int chance, std::string_view message_str)
@@ -40,13 +43,18 @@ void MonraceMessage::emplace(const MonsterMessageType message_type, const int ch
     message.emplace(chance, message_str);
 }
 
-tl::optional<const MonsterMessage &> MonraceMessage::get_message(MonsterMessageType message_type) const
+std::optional<std::string_view> MonraceMessage::get_message(MonsterMessageType message_type) const
 {
     const auto &message = this->messages.find(message_type);
     if (message == this->messages.end()) {
-        return tl::nullopt;
+        return std::nullopt;
     }
     return message->second.get_message();
+}
+
+bool MonraceMessage::has_message(MonsterMessageType message_type) const
+{
+    return this->messages.contains(message_type);
 }
 
 MonraceMessageList MonraceMessageList::instance{};
@@ -63,10 +71,13 @@ void MonraceMessageList::emplace(const int monrace_id, const MonsterMessageType 
     message.emplace(message_type, chance, message_str);
 }
 
-tl::optional<const MonsterMessage &> MonraceMessageList::get_message(const int monrace_id, const MonsterMessageType message_type) const
+std::optional<std::string_view> MonraceMessageList::get_message(const int monrace_id, const MonsterMessageType message_type) const
 {
     auto message = this->messages.find(monrace_id);
     if (message == this->messages.end()) {
+        return this->default_messages.get_message(message_type);
+    }
+    if (!message->second.has_message(message_type)) {
         return this->default_messages.get_message(message_type);
     }
     return message->second.get_message(message_type);

--- a/src/system/monrace/monrace-message.h
+++ b/src/system/monrace/monrace-message.h
@@ -2,16 +2,15 @@
 
 #include "monster-race/race-speak-flags.h"
 #include <map>
+#include <optional>
 #include <string>
 #include <string_view>
-#include <tl/optional.hpp>
 #include <vector>
 
 class MonsterMessage {
 public:
     MonsterMessage(int chance, std::string_view message);
-    int get_message_chance() const;
-    const std::string &get_message() const;
+    std::optional<std::string_view> get_message() const;
 
 private:
     int chance;
@@ -20,7 +19,7 @@ private:
 
 class MonsterMessageList {
 public:
-    tl::optional<const MonsterMessage &> get_message() const;
+    std::optional<std::string_view> get_message() const;
     void emplace(const int chance, std::string_view message_str);
 
 private:
@@ -29,7 +28,8 @@ private:
 
 class MonraceMessage {
 public:
-    tl::optional<const MonsterMessage &> get_message(MonsterMessageType message_type) const;
+    std::optional<std::string_view> get_message(MonsterMessageType message_type) const;
+    bool has_message(MonsterMessageType message_type) const;
     void emplace(const MonsterMessageType message_type, const int chance, std::string_view message_str);
 
 private:
@@ -45,7 +45,7 @@ public:
     ~MonraceMessageList() = default;
 
     static MonraceMessageList &get_instance();
-    tl::optional<const MonsterMessage &> get_message(const int monrace_id, const MonsterMessageType message_type) const;
+    std::optional<std::string_view> get_message(const int monrace_id, const MonsterMessageType message_type) const;
     void emplace(const int monrace_id, const MonsterMessageType message_type, const int chance, std::string_view message_str);
     void emplace_default(const MonsterMessageType message_type, const int chance, std::string_view message_str);
 


### PR DESCRIPTION
確率でメッセージを表示する処理は共通なのでMonsterMessage::get_message()内に移動する。