### PR TITLE
変愚「[Refactor] process_speak_sound()の整理 #5133」のマージ

### DIFF
--- a/src/monster-floor/monster-move.cpp
+++ b/src/monster-floor/monster-move.cpp
@@ -38,6 +38,7 @@
 #include "system/terrain/terrain-definition.h"
 #include "target/projection-path-calculator.h"
 #include "util/bit-flags-calculator.h"
+#include "util/string-processor.h"
 #include "view/display-messages.h"
 
 static bool check_hp_for_terrain_destruction(const TerrainType &terrain, const MonsterEntity &monster)
@@ -539,7 +540,7 @@ static std::optional<MonsterMessageType> get_speak_type(const MonsterEntity &mon
  * @param player_ptr プレイヤーへの参照ポインタ
  * @param message 対応するメッセージ
  */
-void process_sound(PlayerType *player_ptr, std::string_view message)
+void show_sound_message(PlayerType *player_ptr, std::string_view message)
 {
     if (disturb_minor) {
         disturb(player_ptr, false, false);
@@ -548,14 +549,56 @@ void process_sound(PlayerType *player_ptr, std::string_view message)
 }
 
 /*!
- * @brief モンスターを喋らせたり足音を立てたりする
+ * @brief モンスターの足音を立てる
+ * @param player_ptr プレイヤーへの参照ポインタ
+ * @param m_idx モンスターID
+ */
+void process_sound(PlayerType *player_ptr, MONSTER_IDX m_idx)
+{
+    if (AngbandSystem::get_instance().is_phase_out()) {
+        return;
+    }
+
+    const auto &floor = *player_ptr->current_floor_ptr;
+    const auto &monster = floor.m_list[m_idx];
+    const auto &monrace = monster.get_monrace();
+
+    if (monster.ml || player_ptr->skill_srh < randint1(100)) {
+        return;
+    }
+
+    if (monster.cdis <= MAX_PLAYER_SIGHT / 2) {
+        const auto message = monrace.get_message(MonsterMessageType::WALK_CLOSERANGE);
+        if (message) {
+            show_sound_message(player_ptr, *message);
+        }
+        return;
+    }
+    if (monster.cdis <= MAX_PLAYER_SIGHT) {
+        const auto message = monrace.get_message(MonsterMessageType::WALK_MIDDLERANGE);
+        if (message) {
+            show_sound_message(player_ptr, *message);
+        }
+        return;
+    }
+    if (monster.cdis <= MAX_PLAYER_SIGHT * 2) {
+        const auto message = monrace.get_message(MonsterMessageType::WALK_LONGRANGE);
+        if (message) {
+            show_sound_message(player_ptr, *message);
+        }
+        return;
+    }
+}
+
+/*!
+ * @brief モンスターを喋らせる
  * @param player_ptr プレイヤーへの参照ポインタ
  * @param m_idx モンスターID
  * @param oy モンスターが元々いたY座標
  * @param ox モンスターが元々いたX座標
  * @param aware モンスターがプレイヤーに気付いているならばTRUE、超隠密状態ならばFALSE
  */
-void process_speak_sound(PlayerType *player_ptr, MONSTER_IDX m_idx, POSITION oy, POSITION ox, bool aware)
+void process_speak(PlayerType *player_ptr, MONSTER_IDX m_idx, POSITION oy, POSITION ox, bool aware)
 {
     const Pos2D pos(oy, ox);
     if (AngbandSystem::get_instance().is_phase_out()) {
@@ -565,34 +608,8 @@ void process_speak_sound(PlayerType *player_ptr, MONSTER_IDX m_idx, POSITION oy,
     const auto &floor = *player_ptr->current_floor_ptr;
     const auto &monster = floor.m_list[m_idx];
     const auto &monrace = monster.get_monrace();
-
-    if (player_ptr->skill_srh > randint1(100)) {
-        if (!monster.ml && (monster.cdis <= MAX_PLAYER_SIGHT / 2)) {
-            const auto message = monrace.get_message(MonsterMessageType::WALK_CLOSERANGE);
-            if (message) {
-                process_sound(player_ptr, *message);
-            }
-            return;
-        }
-        if (!monster.ml && (monster.cdis <= MAX_PLAYER_SIGHT)) {
-            const auto message = monrace.get_message(MonsterMessageType::WALK_MIDDLERANGE);
-            if (message) {
-                process_sound(player_ptr, *message);
-            }
-            return;
-        }
-        if (!monster.ml && (monster.cdis <= MAX_PLAYER_SIGHT * 2)) {
-            const auto message = monrace.get_message(MonsterMessageType::WALK_LONGRANGE);
-            if (message) {
-                process_sound(player_ptr, *message);
-            }
-            return;
-        }
-    }
-
     constexpr auto chance_speak = 8;
     auto vociferous = monrace.r_misc_flags.has(MonsterMiscType::VOCIFEROUS) && (monster.cdis <= MAX_PLAYER_SIGHT * 2) && one_in_(chance_speak / 3 + 1);
-
     const auto p_pos = player_ptr->get_position();
     const auto can_speak = monster.get_appearance_monrace().speak_flags.any();
     if ((!vociferous) && (!can_speak || !aware || !floor.has_los_at({ oy, ox }) || !projectable(floor, p_pos, pos, p_pos))) {
@@ -605,8 +622,8 @@ void process_speak_sound(PlayerType *player_ptr, MONSTER_IDX m_idx, POSITION oy,
         return;
     }
 
-    const auto monmessage = monrace.get_message(*message_type);
-    if (monmessage) {
-        msg_format(_("%s^%s", "%s^ %s"), m_name.data(), monmessage->data());
+    const auto monster_message = monrace.get_message(*message_type);
+    if (monster_message) {
+        msg_print(_("{}{}", "{} {}"), str_upcase_first(m_name), *monster_message);
     }
 }

--- a/src/monster-floor/monster-move.h
+++ b/src/monster-floor/monster-move.h
@@ -14,4 +14,5 @@ class PlayerType;
 struct turn_flags;
 void activate_explosive_rune(PlayerType *player_ptr, const Pos2D &pos, const MonraceDefinition &monrace);
 bool process_monster_movement(PlayerType *player_ptr, turn_flags *turn_flags_ptr, const MonsterMovementDirectionList &mmdl, const Pos2D &pos, int *count);
-void process_speak_sound(PlayerType *player_ptr, MONSTER_IDX m_idx, POSITION oy, POSITION ox, bool aware);
+void process_sound(PlayerType *player_ptr, MONSTER_IDX m_idx);
+void process_speak(PlayerType *player_ptr, MONSTER_IDX m_idx, POSITION oy, POSITION ox, bool aware);

--- a/src/monster/monster-processor.cpp
+++ b/src/monster/monster-processor.cpp
@@ -242,7 +242,8 @@ void process_monster(PlayerType *player_ptr, MONSTER_IDX m_idx)
     process_monster_spawn_zanki(player_ptr, m_idx);
     process_monster_change_feat(player_ptr, m_idx);
     process_special(player_ptr, m_idx);
-    process_speak_sound(player_ptr, m_idx, oy, ox, turn_flags_ptr->aware);
+    process_sound(player_ptr, m_idx);
+    process_speak(player_ptr, m_idx, oy, ox, turn_flags_ptr->aware);
     if (cast_spell(player_ptr, m_idx, turn_flags_ptr->aware)) {
         return;
     }


### PR DESCRIPTION
モンスターの足音関連処理が大きくなり、見通しが悪くなったのでprocess_speak_sound()を分割整理する。 ゲームの挙動は変更しない。