### PR TITLE
変愚「[Feature] モンスターメッセージに名前を使用するオプションの追加 #5135」のマージ

### DIFF
--- a/lib/edit/MonsterMessages.jsonc
+++ b/lib/edit/MonsterMessages.jsonc
@@ -8318,6 +8318,7 @@
                 {
                     "action": "MESSAGE_REFLECT",
                     "chance": 1,
+                    "use_name": false,
                     "message": {
                         "ja": [
                             "攻撃は跳ね返った！"

--- a/schema/MonraceDefinitions.schema.json
+++ b/schema/MonraceDefinitions.schema.json
@@ -726,6 +726,10 @@
                                     "minimum": 1,
                                     "maximum": 100
                                 },
+                                "use_name": {
+                                    "type": "boolean",
+                                    "description": "メッセージの先頭にモンスター名を表示する。"
+                                },
                                 "message": {
                                     "type": "object",
                                     "description": "メッセージ",

--- a/schema/MonsterMessages.schema.json
+++ b/schema/MonsterMessages.schema.json
@@ -64,6 +64,10 @@
                                 "minimum": 1,
                                 "maximum": 100
                             },
+                            "use_name": {
+                                "type": "boolean",
+                                "description": "メッセージの先頭にモンスター名を表示する。"
+                            },
                             "message": {
                                 "type": "object",
                                 "description": "メッセージ",

--- a/src/effect/effect-processor.cpp
+++ b/src/effect/effect-processor.cpp
@@ -289,8 +289,9 @@ ProjectResult project(PlayerType *player_ptr, const MONSTER_IDX src_idx, POSITIO
                     }
 
                     if (is_seen(player_ptr, monster)) {
+                        const auto m_name = monster.ml ? monster_desc(player_ptr, monster, 0) : std::string(_("それ", "It"));
                         sound(SoundKind::REFLECT);
-                        const auto reflect_message = monrace.get_message(MonsterMessageType::MESSAGE_REFLECT);
+                        const auto reflect_message = monrace.get_message(m_name, MonsterMessageType::MESSAGE_REFLECT);
                         if (reflect_message) {
                             msg_print(*reflect_message);
                         }

--- a/src/info-reader/message-reader.cpp
+++ b/src/info-reader/message-reader.cpp
@@ -98,6 +98,15 @@ static errr set_mon_message(const nlohmann::json &group_data)
             return err;
         }
 
+        bool use_name = true;
+        const auto use_name_iter = message.value().find("use_name");
+        if (use_name_iter != message.value().end()) {
+            const auto &use_name_data = use_name_iter.value();
+            if (auto err = info_set_bool(use_name_data, use_name, false)) {
+                return err;
+            }
+        }
+
         const auto language_iter = message.value().find("message");
         if (language_iter == message.value().end() || !language_iter->is_object()) {
             return PARSE_ERROR_TOO_FEW_ARGUMENTS;
@@ -142,10 +151,10 @@ static errr set_mon_message(const nlohmann::json &group_data)
 #endif
             if (has_id_list) {
                 for (auto id : id_list) {
-                    MonraceMessageList::get_instance().emplace(id, action->second, chance, str);
+                    MonraceMessageList::get_instance().emplace(id, action->second, chance, use_name, str);
                 }
             } else {
-                MonraceMessageList::get_instance().emplace_default(action->second, chance, str);
+                MonraceMessageList::get_instance().emplace_default(action->second, chance, use_name, str);
             }
         }
     }

--- a/src/info-reader/race-reader.cpp
+++ b/src/info-reader/race-reader.cpp
@@ -725,12 +725,21 @@ static errr set_mon_message(const nlohmann::json &message_data, MonraceDefinitio
             return err;
         }
 
+        bool use_name = true;
+        const auto use_name_iter = message.value().find("use_name");
+        if (use_name_iter != message.value().end()) {
+            const auto &use_name_data = use_name_iter.value();
+            if (auto err = info_set_bool(use_name_data, use_name, false)) {
+                return err;
+            }
+        }
+
         std::string str;
         if (auto err = info_set_string(message.value()["message"], str, false)) {
             return err;
         }
 
-        MonraceMessageList::get_instance().emplace((int)monrace.idx, action->second, chance, str);
+        MonraceMessageList::get_instance().emplace((int)monrace.idx, action->second, chance, use_name, str);
     }
     return PARSE_ERROR_NONE;
 }

--- a/src/monster-floor/monster-move.cpp
+++ b/src/monster-floor/monster-move.cpp
@@ -38,7 +38,6 @@
 #include "system/terrain/terrain-definition.h"
 #include "target/projection-path-calculator.h"
 #include "util/bit-flags-calculator.h"
-#include "util/string-processor.h"
 #include "view/display-messages.h"
 
 static bool check_hp_for_terrain_destruction(const TerrainType &terrain, const MonsterEntity &monster)
@@ -566,23 +565,24 @@ void process_sound(PlayerType *player_ptr, MONSTER_IDX m_idx)
     if (monster.ml || player_ptr->skill_srh < randint1(100)) {
         return;
     }
+    const auto m_name = std::string(_("それ", "It"));
 
     if (monster.cdis <= MAX_PLAYER_SIGHT / 2) {
-        const auto message = monrace.get_message(MonsterMessageType::WALK_CLOSERANGE);
+        const auto message = monrace.get_message(m_name, MonsterMessageType::WALK_CLOSERANGE);
         if (message) {
             show_sound_message(player_ptr, *message);
         }
         return;
     }
     if (monster.cdis <= MAX_PLAYER_SIGHT) {
-        const auto message = monrace.get_message(MonsterMessageType::WALK_MIDDLERANGE);
+        const auto message = monrace.get_message(m_name, MonsterMessageType::WALK_MIDDLERANGE);
         if (message) {
             show_sound_message(player_ptr, *message);
         }
         return;
     }
     if (monster.cdis <= MAX_PLAYER_SIGHT * 2) {
-        const auto message = monrace.get_message(MonsterMessageType::WALK_LONGRANGE);
+        const auto message = monrace.get_message(m_name, MonsterMessageType::WALK_LONGRANGE);
         if (message) {
             show_sound_message(player_ptr, *message);
         }
@@ -622,8 +622,8 @@ void process_speak(PlayerType *player_ptr, MONSTER_IDX m_idx, POSITION oy, POSIT
         return;
     }
 
-    const auto monster_message = monrace.get_message(*message_type);
+    const auto monster_message = monrace.get_message(m_name, *message_type);
     if (monster_message) {
-        msg_print(_("{}{}", "{} {}"), str_upcase_first(m_name), *monster_message);
+        msg_print(*monster_message);
     }
 }

--- a/src/monster/monster-damage.cpp
+++ b/src/monster/monster-damage.cpp
@@ -42,7 +42,6 @@
 #include "timed-effect/timed-effects.h"
 #include "tracking/health-bar-tracker.h"
 #include "tracking/lore-tracker.h"
-#include "util/string-processor.h"
 #include "view/display-messages.h"
 #include "world/world.h"
 #include <optional>
@@ -254,9 +253,9 @@ void MonsterDamageProcessor::dying_scream(std::string_view m_name)
         return;
     }
 
-    const auto death_message = r_ref.get_message(MonsterMessageType::SPEAK_DEATH);
+    const auto death_message = r_ref.get_message(m_name, MonsterMessageType::SPEAK_DEATH);
     if (death_message) {
-        msg_print("{} {}", str_upcase_first(m_name), *death_message);
+        msg_print(*death_message);
     }
 
 #ifdef WORLD_SCORE

--- a/src/monster/monster-processor.cpp
+++ b/src/monster/monster-processor.cpp
@@ -78,7 +78,6 @@
 #include "system/terrain/terrain-list.h"
 #include "target/projection-path-calculator.h"
 #include "tracking/lore-tracker.h"
-#include "util/string-processor.h"
 #include "view/display-messages.h"
 #include "world/world.h"
 
@@ -986,9 +985,9 @@ bool process_stalking(PlayerType *player_ptr, MONSTER_IDX m_idx)
     disturb(player_ptr, true, true);
 
     if (see_monster(player_ptr, m_idx)) {
-        const auto message_stalker = monrace.get_message(MonsterMessageType::MESSAGE_STALKER);
+        const auto message_stalker = monrace.get_message(m_name, MonsterMessageType::MESSAGE_STALKER);
         if (message_stalker) {
-            msg_print(_("{}{}", "{} {}"), str_upcase_first(m_name), *message_stalker);
+            msg_print(*message_stalker);
         }
     }
 

--- a/src/system/monrace/monrace-definition.cpp
+++ b/src/system/monrace/monrace-definition.cpp
@@ -330,9 +330,9 @@ bool MonraceDefinition::has_reinforce() const
     return it != end;
 }
 
-std::optional<std::string_view> MonraceDefinition::get_message(const MonsterMessageType message_type) const
+std::optional<std::string> MonraceDefinition::get_message(std::string_view monster_name, const MonsterMessageType message_type) const
 {
-    return MonraceMessageList::get_instance().get_message((int)this->idx, message_type);
+    return MonraceMessageList::get_instance().get_message((int)this->idx, monster_name, message_type);
 }
 
 const std::vector<DropArtifact> &MonraceDefinition::get_drop_artifacts() const

--- a/src/system/monrace/monrace-definition.h
+++ b/src/system/monrace/monrace-definition.h
@@ -195,7 +195,7 @@ public:
     int calc_capture_value() const;
     std::string build_eldritch_horror_message(std::string_view description) const;
     bool has_reinforce() const;
-    std::optional<std::string_view> get_message(const MonsterMessageType message_type) const;
+    std::optional<std::string> get_message(std::string_view monster_name, const MonsterMessageType message_type) const;
     const std::vector<DropArtifact> &get_drop_artifacts() const;
     const std::vector<Reinforce> &get_reinforces() const;
     bool can_generate() const;

--- a/src/system/monrace/monrace-message.h
+++ b/src/system/monrace/monrace-message.h
@@ -5,22 +5,25 @@
 #include <optional>
 #include <string>
 #include <string_view>
+#include <tl/optional.hpp>
 #include <vector>
 
 class MonsterMessage {
 public:
-    MonsterMessage(int chance, std::string_view message);
+    MonsterMessage(int chance, bool use_name, std::string_view message);
     std::optional<std::string_view> get_message() const;
+    bool start_with_monname() const;
 
 private:
     int chance;
+    bool use_name;
     std::string message;
 };
 
 class MonsterMessageList {
 public:
-    std::optional<std::string_view> get_message() const;
-    void emplace(const int chance, std::string_view message_str);
+    tl::optional<const MonsterMessage &> get_message_obj() const;
+    void emplace(const int chance, bool use_name, std::string_view message_str);
 
 private:
     std::vector<MonsterMessage> messages;
@@ -28,9 +31,9 @@ private:
 
 class MonraceMessage {
 public:
-    std::optional<std::string_view> get_message(MonsterMessageType message_type) const;
+    tl::optional<const MonsterMessage &> get_message_obj(MonsterMessageType message_type) const;
     bool has_message(MonsterMessageType message_type) const;
-    void emplace(const MonsterMessageType message_type, const int chance, std::string_view message_str);
+    void emplace(const MonsterMessageType message_type, const int chance, bool use_name, std::string_view message_str);
 
 private:
     std::map<MonsterMessageType, MonsterMessageList> messages;
@@ -45,13 +48,14 @@ public:
     ~MonraceMessageList() = default;
 
     static MonraceMessageList &get_instance();
-    std::optional<std::string_view> get_message(const int monrace_id, const MonsterMessageType message_type) const;
-    void emplace(const int monrace_id, const MonsterMessageType message_type, const int chance, std::string_view message_str);
-    void emplace_default(const MonsterMessageType message_type, const int chance, std::string_view message_str);
+    std::optional<std::string> get_message(const int monrace_id, std::string_view monrace_name, const MonsterMessageType message_type);
+    void emplace(const int monrace_id, const MonsterMessageType message_type, const int chance, bool use_name, std::string_view message_str);
+    void emplace_default(const MonsterMessageType message_type, const int chance, bool use_name, std::string_view message_str);
 
 private:
     MonraceMessageList() = default;
     static MonraceMessageList instance;
+    tl::optional<const MonsterMessage &> get_message_obj(const int monrace_id, const MonsterMessageType message_type) const;
 
     std::map<int, MonraceMessage> messages;
     MonraceMessage default_messages;


### PR DESCRIPTION
モンスターが発するメッセージには先頭にモンスター名を表記するものとしないものが混在している。
JSON設定ファイルにuse_nameを追加し、これを選択可能とする。
デフォルトはtrueで名前を表記し、この場合use_nameは省略できる。