### PR TITLE
変愚「【バグ】"make dist" does not include MonsterMessages files in the archive #5138」のマージ

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -26,6 +26,7 @@ schema_files = \
 	schema/BaseitemDefinitions.schema.json \
 	schema/ClassMagicDefinitions.schema.json \
 	schema/MonraceDefinitions.schema.json \
+	schema/MonsterMessages.schema.json \
 	schema/SpellDefinitions.schema.json
 
 EXTRA_DIST = \

--- a/lib/edit/Makefile.am
+++ b/lib/edit/Makefile.am
@@ -5,9 +5,10 @@ AUTOMAKE_OPTIONS = foreign
 angband_files = \
 	ArtifactDefinitions.jsonc BaseitemDefinitions.jsonc ClassMagicDefinitions.jsonc \
 	ClassSkillDefinitions.txt DungeonDefinitions.txt EgoDefinitions.txt \
-	MonraceDefinitions.jsonc QuestDefinitionList.txt QuestPreferences.txt \
-	SpellDefinitions.jsonc TerrainDefinitions.txt TownDefinitionList.txt \
-	TownPreferences.txt VaultDefinitions.txt WildernessDefinition.txt
+	MonraceDefinitions.jsonc MonsterMessages.jsonc QuestDefinitionList.txt \
+	QuestPreferences.txt SpellDefinitions.jsonc TerrainDefinitions.txt \
+	TownDefinitionList.txt TownPreferences.txt VaultDefinitions.txt \
+	WildernessDefinition.txt
 
 EXTRA_DIST = \
   $(angband_files)


### PR DESCRIPTION
Resolves https://github.com/hengband/hengband/issues/5138 .