### PR TITLE
変愚「[Refactor] 死亡時召喚処理の統一 #5168」のマージ

### DIFF
--- a/src/monster-floor/special-death-switcher.cpp
+++ b/src/monster-floor/special-death-switcher.cpp
@@ -61,62 +61,41 @@ static BIT_FLAGS dead_mode(MonsterDeath *md_ptr)
 }
 
 /*!
- * @brief 死亡時召喚処理 (今のところ自分自身のみ)
+ * @brief 死亡時召喚処理
  * @param player_ptr プレイヤーへの参照ポインタ
  * @param md_ptr モンスター撃破構造体への参照ポインタ
- * @param type 召喚タイプ
- * @param probability 召喚確率 (計算式：1 - 1/probability)
- * @param radius 召喚半径 (モンスターが死亡した座標から半径何マス以内に召喚させるか)
- * @param message 召喚時のメッセージ
+ * @param summon_data 召喚情報
+ * @return プレイヤーが死亡時召喚を視認していればtrue, 視認しなければfalse, 召喚失敗時はtl::nullopt
  */
-static void summon_self(PlayerType *player_ptr, MonsterDeath *md_ptr, summon_type type, int probability, POSITION radius, concptr message)
+static tl::optional<bool> final_summon(PlayerType *player_ptr, MonsterDeath *md_ptr, const MonsterSummon &summon_data)
 {
     const auto &floor = *player_ptr->current_floor_ptr;
-    if (floor.inside_arena || AngbandSystem::get_instance().is_phase_out() || one_in_(probability)) {
-        return;
+    if (floor.inside_arena || AngbandSystem::get_instance().is_phase_out() || !evaluate_percent(summon_data.probability)) {
+        return tl::nullopt;
     }
-
+    bool notice = false;
+    const auto summon_num = rand_range(summon_data.min_num, summon_data.max_num);
     const auto p_pos = player_ptr->get_position();
-    auto m_pos = md_ptr->get_position();
-    auto attempts = 0;
-    for (; attempts < 100; attempts++) {
-        m_pos = scatter(player_ptr, md_ptr->get_position(), radius, PROJECT_NONE);
-        if (floor.contains(m_pos) && floor.can_generate_monster_at(m_pos) && (p_pos != m_pos)) {
+    for (int i = 0; i < summon_num; i++) {
+        auto m_pos = md_ptr->get_position();
+        auto attempts = 0;
+        for (; attempts < 100; attempts++) {
+            m_pos = scatter(player_ptr, md_ptr->get_position(), summon_data.radius, PROJECT_NONE);
+            if (floor.contains(m_pos) && floor.can_generate_monster_at(m_pos) && (p_pos != m_pos)) {
+                break;
+            }
+        }
+        if (attempts == 100) {
             break;
         }
-    }
 
-    if (attempts == 100) {
-        return;
-    }
-
-    BIT_FLAGS mode = dead_mode(md_ptr);
-    if (summon_specific(player_ptr, m_pos.y, m_pos.x, 100, type, mode) && player_can_see_bold(player_ptr, m_pos.y, m_pos.x)) {
-        msg_print(message);
-    }
-}
-
-static void on_dead_pink_horror(PlayerType *player_ptr, MonsterDeath *md_ptr)
-{
-    if (player_ptr->current_floor_ptr->inside_arena || AngbandSystem::get_instance().is_phase_out()) {
-        return;
-    }
-
-    bool notice = false;
-    const int blue_horrors = 2;
-    for (int i = 0; i < blue_horrors; i++) {
-        POSITION wy = md_ptr->md_y;
-        POSITION wx = md_ptr->md_x;
         BIT_FLAGS mode = dead_mode(md_ptr);
-        if (summon_specific(player_ptr, wy, wx, 100, SUMMON_BLUE_HORROR, mode) && player_can_see_bold(player_ptr, wy, wx)) {
+        const auto summon_src = md_ptr->m_ptr->is_pet() ? -1 : md_ptr->m_idx;
+        if (summon_named_creature(player_ptr, summon_src, m_pos.y, m_pos.x, summon_data.id, mode) && player_can_see_bold(player_ptr, m_pos.y, m_pos.x)) {
             notice = true;
         }
     }
-
-    if (notice) {
-        sound(SoundKind::SUMMON);
-        msg_print(_("ピンク・ホラーは分裂した！", "The Pink horror divides!"));
-    }
+    return notice;
 }
 
 static void on_dead_spawn_monsters(PlayerType *player_ptr, MonsterDeath *md_ptr)
@@ -309,16 +288,6 @@ static void on_dead_raal(PlayerType *player_ptr, MonsterDeath *md_ptr)
     }
 }
 
-/*!
- * @brief 6/7の確率で、20マス以内に暁の戦士自身を召喚する
- * @param player_ptr プレイヤーへの参照ポインタ
- * @param md_ptr モンスター撃破構造体への参照ポインタ
- */
-static void on_dead_dawn(PlayerType *player_ptr, MonsterDeath *md_ptr)
-{
-    summon_self(player_ptr, md_ptr, SUMMON_DAWN, 7, 20, _("新たな戦士が現れた！", "A new warrior steps forth!"));
-}
-
 static void on_dead_ninja(PlayerType *player_ptr, MonsterDeath *md_ptr)
 {
     if (is_seen(player_ptr, *md_ptr->m_ptr)) {
@@ -406,68 +375,6 @@ static void on_dead_can_angel(PlayerType *player_ptr, MonsterDeath *md_ptr)
     (void)drop_near(player_ptr, &item, md_ptr->get_position());
 }
 
-static void on_dead_aqua_illusion(PlayerType *player_ptr, MonsterDeath *md_ptr)
-{
-    if (player_ptr->current_floor_ptr->inside_arena || AngbandSystem::get_instance().is_phase_out()) {
-        return;
-    }
-
-    bool notice = false;
-    const int popped_bubbles = 4;
-    for (int i = 0; i < popped_bubbles; i++) {
-        POSITION wy = md_ptr->md_y;
-        POSITION wx = md_ptr->md_x;
-        bool pet = md_ptr->m_ptr->is_pet();
-        BIT_FLAGS mode = dead_mode(md_ptr);
-        auto smaller_bubble = md_ptr->m_ptr->r_idx - 1;
-        if (summon_named_creature(player_ptr, (pet ? -1 : md_ptr->m_idx), wy, wx, smaller_bubble, mode) && player_can_see_bold(player_ptr, wy, wx)) {
-            notice = true;
-        }
-    }
-
-    if (notice) {
-        msg_print(_("泡が弾けた！", "The bubble pops!"));
-        sound(SoundKind::SUMMON);
-    }
-}
-
-/*!
- * @brief 7/8の確率で、5マス以内にトーテムモアイ自身を召喚する
- * @param player_ptr プレイヤーへの参照ポインタ
- * @param md_ptr モンスター撃破構造体への参照ポインタ
- */
-static void on_dead_totem_moai(PlayerType *player_ptr, MonsterDeath *md_ptr)
-{
-    summon_self(player_ptr, md_ptr, SUMMON_TOTEM_MOAI, 8, 5, _("新たなモアイが現れた！", "A new moai steps forth!"));
-}
-
-static void on_dead_dragon_centipede(PlayerType *player_ptr, MonsterDeath *md_ptr)
-{
-    if (player_ptr->current_floor_ptr->inside_arena || AngbandSystem::get_instance().is_phase_out()) {
-        return;
-    }
-
-    bool notice = false;
-    const int reproduced_centipede = 2;
-    for (int i = 0; i < reproduced_centipede; i++) {
-        POSITION wy = md_ptr->md_y;
-        POSITION wx = md_ptr->md_x;
-        bool pet = md_ptr->m_ptr->is_pet();
-        BIT_FLAGS mode = dead_mode(md_ptr);
-
-        auto smaller_centipede = md_ptr->m_ptr->r_idx - 1;
-        if (summon_named_creature(player_ptr, (pet ? -1 : md_ptr->m_idx), wy, wx, smaller_centipede, mode) && player_can_see_bold(player_ptr, wy, wx)) {
-            notice = true;
-        }
-    }
-
-    if (notice) {
-        const auto m_name = monster_desc(player_ptr, *md_ptr->m_ptr, MD_NONE);
-        msg_format(_("%sが再生した！", "The %s reproduced!"), m_name.data());
-        sound(SoundKind::SUMMON);
-    }
-}
-
 /*!
  * @brief 装備品の生成を試みる
  * @param player_ptr プレイヤーへの参照ポインタ
@@ -550,48 +457,6 @@ static void drop_specific_item_on_dead(PlayerType *player_ptr, MonsterDeath *md_
     }
 }
 
-static void on_dead_chest_mimic(PlayerType *player_ptr, MonsterDeath *md_ptr)
-{
-    if (player_ptr->current_floor_ptr->inside_arena || AngbandSystem::get_instance().is_phase_out()) {
-        return;
-    }
-
-    auto notice = false;
-    auto mimic_inside = MonraceList::empty_id();
-    auto num_summons = 0;
-    switch (md_ptr->m_ptr->r_idx) {
-    case MonraceId::CHEST_MIMIC_03:
-        mimic_inside = MonraceId::CHEST_MIMIC_02;
-        num_summons = 1;
-        break;
-    case MonraceId::CHEST_MIMIC_04:
-        mimic_inside = MonraceId::CHEST_MIMIC_03;
-        num_summons = 1;
-        break;
-    case MonraceId::CHEST_MIMIC_11:
-        mimic_inside = MonraceId::CHEST_MIMIC_04;
-        num_summons = one_in_(2) ? 3 : 2;
-        break;
-    default:
-        return;
-    }
-
-    for (auto i = 0; i < num_summons; i++) {
-        auto wy = md_ptr->md_y;
-        auto wx = md_ptr->md_x;
-        auto pet = md_ptr->m_ptr->is_pet();
-        BIT_FLAGS mode = dead_mode(md_ptr);
-        if (summon_named_creature(player_ptr, (pet ? -1 : md_ptr->m_idx), wy, wx, mimic_inside, (BIT_FLAGS)mode) && player_can_see_bold(player_ptr, wy, wx)) {
-            notice = true;
-        }
-    }
-
-    if (notice) {
-        msg_print(_("箱の中から新たなミミックが現れた！", "A new mimic appears in the dead mimic!"));
-        sound(SoundKind::SUMMON);
-    }
-}
-
 static void on_dead_mimics(PlayerType *player_ptr, MonsterDeath *md_ptr)
 {
     if (!md_ptr->drop_chosen_item) {
@@ -657,32 +522,37 @@ static void on_dead_swordfish(PlayerType *player_ptr, MonsterDeath *md_ptr, Attr
 
 void switch_special_death(PlayerType *player_ptr, MonsterDeath *md_ptr, AttributeFlags attribute_flags)
 {
-    if (md_ptr->r_ptr->kind_flags.has(MonsterKindType::NINJA)) {
-        on_dead_ninja(player_ptr, md_ptr);
+    auto &monrace = MonraceList::get_instance().get_monrace(md_ptr->r_ptr->idx);
+    const auto &summon_list = monrace.get_final_summons();
+    if (!summon_list.empty()) {
+        auto do_message = false;
+        for (auto &summon_data : summon_list) {
+            if (auto notice = final_summon(player_ptr, md_ptr, summon_data)) {
+                do_message |= *notice;
+            }
+        }
+        if (do_message) {
+            const auto monster_message = monrace.get_message(monrace.name, MonsterMessageType::SPEAK_SPAWN);
+            if (monster_message) {
+                msg_print(*monster_message);
+                sound(SoundKind::SUMMON);
+            }
+        }
         return;
     }
-    on_dead_drop_kind_item(player_ptr, md_ptr);
-    on_dead_drop_tval_item(player_ptr, md_ptr);
-    on_dead_spawn_monsters(player_ptr, md_ptr);
 
     switch (md_ptr->m_ptr->r_idx) {
     case MonraceId::EARTH_DESTROYER:
         on_dead_earth_destroyer(player_ptr, md_ptr);
-        break;
+        return;
     case MonraceId::BOTTLE_GNOME:
         on_dead_bottle_gnome(player_ptr, md_ptr);
-        return;
-    case MonraceId::PINK_HORROR:
-        on_dead_pink_horror(player_ptr, md_ptr);
         return;
     case MonraceId::BLOODLETTER:
         on_dead_bloodletter(player_ptr, md_ptr);
         return;
     case MonraceId::RAAL:
         on_dead_raal(player_ptr, md_ptr);
-        return;
-    case MonraceId::DAWN:
-        on_dead_dawn(player_ptr, md_ptr);
         return;
     case MonraceId::UNMAKER:
         (void)project(player_ptr, md_ptr->m_idx, 6, md_ptr->md_y, md_ptr->md_x, 100, AttributeType::CHAOS, PROJECT_GRID | PROJECT_ITEM | PROJECT_KILL);
@@ -704,21 +574,6 @@ void switch_special_death(PlayerType *player_ptr, MonsterDeath *md_ptr, Attribut
         return;
     case MonraceId::ROLENTO:
         (void)project(player_ptr, md_ptr->m_idx, 3, md_ptr->md_y, md_ptr->md_x, Dice::roll(20, 10), AttributeType::FIRE, PROJECT_GRID | PROJECT_ITEM | PROJECT_KILL);
-        return;
-    case MonraceId::MIDDLE_AQUA_FIRST:
-    case MonraceId::LARGE_AQUA_FIRST:
-    case MonraceId::EXTRA_LARGE_AQUA_FIRST:
-    case MonraceId::MIDDLE_AQUA_SECOND:
-    case MonraceId::LARGE_AQUA_SECOND:
-    case MonraceId::EXTRA_LARGE_AQUA_SECOND:
-        on_dead_aqua_illusion(player_ptr, md_ptr);
-        return;
-    case MonraceId::TOTEM_MOAI:
-        on_dead_totem_moai(player_ptr, md_ptr);
-        return;
-    case MonraceId::DRAGON_CENTIPEDE:
-    case MonraceId::DRAGON_WORM:
-        on_dead_dragon_centipede(player_ptr, md_ptr);
         return;
     case MonraceId::CAIT_SITH:
         if (player_ptr->current_floor_ptr->dun_level <= 0) {
@@ -749,14 +604,9 @@ void switch_special_death(PlayerType *player_ptr, MonsterDeath *md_ptr, Attribut
         return;
     case MonraceId::SWORDFISH:
         on_dead_swordfish(player_ptr, md_ptr, attribute_flags);
-        return;
-    case MonraceId::CHEST_MIMIC_03:
-    case MonraceId::CHEST_MIMIC_04:
-    case MonraceId::CHEST_MIMIC_11:
-        on_dead_chest_mimic(player_ptr, md_ptr);
-        on_dead_mimics(player_ptr, md_ptr);
-        return;
+        break;
     default:
+        on_dead_mimics(player_ptr, md_ptr);
         return;
     }
 }

--- a/src/monster/monster-damage.cpp
+++ b/src/monster/monster-damage.cpp
@@ -157,7 +157,7 @@ bool MonsterDamageProcessor::process_dead_exp_virtue(std::string_view note, cons
     this->show_kill_message(note, m_name);
     this->show_bounty_message(m_name);
     monster_death(this->player_ptr, this->m_idx, true, this->attribute_flags);
-    this->summon_special_unique();
+    delete_monster_idx(this->player_ptr, this->m_idx);
     this->get_exp_from_mon(exp_mon, exp_mon.max_maxhp * 2);
     *this->fear = false;
     return true;
@@ -415,50 +415,6 @@ void MonsterDamageProcessor::set_redraw()
     HealthBarTracker::get_instance().set_flag_if_tracking(this->m_idx);
     if (monster.is_riding()) {
         RedrawingFlagsUpdater::get_instance().set_flag(MainWindowRedrawingFlag::UHEALTH);
-    }
-}
-
-/*
- * @brief 特定ユニークを倒した時に更にユニークを特殊召喚する処理
- * @param m_ptr ダメージを与えた特定ユニークの構造体参照ポインタ
- */
-void MonsterDamageProcessor::summon_special_unique()
-{
-    const auto &monster = this->player_ptr->current_floor_ptr->m_list[this->m_idx];
-    bool is_special_summon = monster.r_idx == MonraceId::IKETA;
-    is_special_summon |= monster.r_idx == MonraceId::DOPPIO;
-    if (!is_special_summon || this->player_ptr->current_floor_ptr->inside_arena || AngbandSystem::get_instance().is_phase_out()) {
-        delete_monster_idx(this->player_ptr, this->m_idx);
-        return;
-    }
-
-    auto dummy_y = monster.fy;
-    auto dummy_x = monster.fx;
-    auto mode = (BIT_FLAGS)0;
-    if (monster.is_pet()) {
-        mode |= PM_FORCE_PET;
-    }
-
-    MonraceId new_unique_idx;
-    concptr mes;
-    switch (monster.r_idx) {
-    case MonraceId::IKETA:
-        new_unique_idx = MonraceId::BIKETAL;
-        mes = _("「ハァッハッハッハ！！私がバイケタルだ！！」", "Uwa-hahaha!  *I* am Biketal!");
-        break;
-    case MonraceId::DOPPIO:
-        new_unique_idx = MonraceId::DIAVOLO;
-        mes = _("「これは『試練』だ　過去に打ち勝てという『試練』とオレは受けとった」", "This is a 'trial'. I took it as a 'trial' to overcome in the past.");
-        break;
-    default: // バグでなければ入らない.
-        new_unique_idx = MonraceList::empty_id();
-        mes = "";
-        break;
-    }
-
-    delete_monster_idx(this->player_ptr, this->m_idx);
-    if (summon_named_creature(this->player_ptr, 0, dummy_y, dummy_x, new_unique_idx, mode)) {
-        msg_print(mes);
     }
 }
 

--- a/src/monster/monster-damage.h
+++ b/src/monster/monster-damage.h
@@ -35,6 +35,5 @@ private:
     void show_explosion_message(std::string_view died_mes, std::string_view m_name);
     void show_bounty_message(std::string_view m_name);
     void set_redraw();
-    void summon_special_unique();
     void add_monster_fear();
 };

--- a/src/system/monrace/monrace-definition.cpp
+++ b/src/system/monrace/monrace-definition.cpp
@@ -962,6 +962,11 @@ void MonraceDefinition::emplace_final_summon(MonraceId id, int probability, int 
     this->final_summons.emplace_back(MonsterSummon(id, probability, min_num, max_num, radius));
 }
 
+const std::vector<MonsterSummon> &MonraceDefinition::get_final_summons() const
+{
+    return this->final_summons;
+}
+
 /*!
  * @brief モンスター闘技場 (ギャンブル)に出場できるかを返す
  * @return 出場可不可

--- a/src/system/monrace/monrace-definition.h
+++ b/src/system/monrace/monrace-definition.h
@@ -275,6 +275,7 @@ public:
 
     void decrement_mob_numbers();
     void emplace_final_summon(MonraceId id, int probability, int min_num, int max_num, int radius);
+    const std::vector<MonsterSummon> &get_final_summons() const;
 
 private:
     std::unordered_map<MonsterMessageType, MonsterMessage> messages; //!< メッセージリスト


### PR DESCRIPTION
 #5150 にて外部読込可能にした死亡時召喚情報を用いて死亡時召喚処理を統一した。