### PR TITLE
変愚「[Fix] アイテムが足下に転がってきたメッセージが表示されない #5171」のマージ

### DIFF
--- a/src/floor/floor-object.cpp
+++ b/src/floor/floor-object.cpp
@@ -300,8 +300,9 @@ ObjectIndexList &get_o_idx_list_contains(FloorType &floor, OBJECT_IDX o_idx)
  * @param j_ptr 落としたいアイテムへの参照ポインタ
  * @param pos 配置したい座標
  * @param chance 投擲物の消滅率(%)。投擲物以外はnullopt
+ * @param show_drop_message 足下に転がってきたアイテムのメッセージを表示するかどうか (デフォルトは表示する)
  */
-short drop_near(PlayerType *player_ptr, ItemEntity *j_ptr, const Pos2D &pos, tl::optional<int> chance)
+short drop_near(PlayerType *player_ptr, ItemEntity *j_ptr, const Pos2D &pos, tl::optional<int> chance, bool show_drop_message)
 {
 #ifdef JP
 #else
@@ -497,7 +498,7 @@ short drop_near(PlayerType *player_ptr, ItemEntity *j_ptr, const Pos2D &pos, tl:
         RedrawingFlagsUpdater::get_instance().set_flags(flags);
     }
 
-    if (chance && is_located) {
+    if (show_drop_message && is_located) {
         msg_print(_("何かが足下に転がってきた。", "You feel something roll beneath your feet."));
     }
 

--- a/src/floor/floor-object.h
+++ b/src/floor/floor-object.h
@@ -22,7 +22,7 @@ void excise_object_idx(FloorType &floor, OBJECT_IDX o_idx);
 void delete_items(PlayerType *player_ptr, std::vector<OBJECT_IDX> delete_i_idx_list);
 void delete_items(PlayerType *player_ptr, ObjectIndexList &o_idx_list);
 ObjectIndexList &get_o_idx_list_contains(FloorType &floor, OBJECT_IDX o_idx);
-short drop_near(PlayerType *player_ptr, ItemEntity *o_ptr, const Pos2D &pos, tl::optional<int> chance = tl::nullopt);
+short drop_near(PlayerType *player_ptr, ItemEntity *o_ptr, const Pos2D &pos, tl::optional<int> chance = tl::nullopt, bool show_drop_message = true);
 void floor_item_charges(const FloorType &floor, INVENTORY_IDX i_idx);
 void floor_item_describe(PlayerType *player_ptr, INVENTORY_IDX i_idx);
 ItemEntity *choose_object(PlayerType *player_ptr, short *initial_i_idx, concptr q, concptr s, BIT_FLAGS option, const ItemTester &item_tester = AllMatchItemTester());

--- a/src/inventory/inventory-object.cpp
+++ b/src/inventory/inventory-object.cpp
@@ -158,7 +158,7 @@ void drop_from_inventory(PlayerType *player_ptr, INVENTORY_IDX i_idx, ITEM_NUMBE
     item.number = amt;
     const auto item_name = describe_flavor(player_ptr, item, 0);
     msg_format(_("%s(%c)を落とした。", "You drop %s (%c)."), item_name.data(), index_to_label(i_idx));
-    (void)drop_near(player_ptr, &item, player_ptr->get_position());
+    (void)drop_near(player_ptr, &item, player_ptr->get_position(), tl::nullopt, false);
     vary_item(player_ptr, i_idx, -amt);
 }
 

--- a/src/inventory/pack-overflow.cpp
+++ b/src/inventory/pack-overflow.cpp
@@ -31,7 +31,7 @@ void pack_overflow(PlayerType *player_ptr)
 
     const auto item_name = describe_flavor(player_ptr, item, 0);
     msg_format(_("%s(%c)を落とした。", "You drop %s (%c)."), item_name.data(), index_to_label(INVEN_PACK));
-    (void)drop_near(player_ptr, &item, player_ptr->get_position());
+    (void)drop_near(player_ptr, &item, player_ptr->get_position(), tl::nullopt, false);
 
     vary_item(player_ptr, INVEN_PACK, -255);
     handle_stuff(player_ptr);


### PR DESCRIPTION
a3d4b473 のリファクタリング時に意図せず表示されなくなってしまっている。
メッセージを表示するかどうかの引数を追加し、リファクタリング前と同様に
表示するべき時は表示するよう修正する。