### PR TITLE
(Item)[Fix] `make_object()` で既に `restrict` が指定されている場合クッソ汚いものが生成されないよう…

### DIFF
--- a/src/floor/floor-object.cpp
+++ b/src/floor/floor-object.cpp
@@ -141,7 +141,7 @@ tl::optional<ItemEntity> make_object(PlayerType *player_ptr, BIT_FLAGS mode, Bas
         }
     }
 
-    if ((one_in_(prob) || any_bits(mode, AM_NASTY))) {
+    if ((one_in_(prob) || any_bits(mode, AM_NASTY)) && !restrict) {
         restrict = kind_is_nasty;
     }
 


### PR DESCRIPTION
…に修正。