### PR TITLE
変愚「[Refactor] 固定アーティファクトの装備判定 #5178」のマージ

### DIFF
--- a/src/action/movement-execution.cpp
+++ b/src/action/movement-execution.cpp
@@ -142,17 +142,6 @@ void exe_movement(PlayerType *player_ptr, const Direction &dir, bool do_pickup, 
 
     const auto &monster = floor.m_list[grid.m_idx];
 
-    // @todo 「特定の武器を装備している」旨のメソッドを別途作る
-    constexpr auto stormbringer = FixedArtifactId::STORMBRINGER;
-    auto is_stormbringer = false;
-    if (player_ptr->inventory[INVEN_MAIN_HAND]->is_specific_artifact(stormbringer)) {
-        is_stormbringer = true;
-    }
-
-    if (player_ptr->inventory[INVEN_SUB_HAND]->is_specific_artifact(stormbringer)) {
-        is_stormbringer = true;
-    }
-
     auto &terrain = grid.get_terrain();
     auto p_can_kill_walls = has_kill_wall(player_ptr);
     p_can_kill_walls &= terrain.flags.has(TerrainCharacteristics::HURT_DISI);
@@ -182,7 +171,7 @@ void exe_movement(PlayerType *player_ptr, const Direction &dir, bool do_pickup, 
                 health_track(player_ptr, grid.m_idx);
             }
 
-            if ((is_stormbringer && (randint1(1000) > 666)) || PlayerClass(player_ptr).equals(PlayerClassType::BERSERKER)) {
+            if ((player_ptr->is_wielding(FixedArtifactId::STORMBRINGER) && (randint1(1000) > 666)) || PlayerClass(player_ptr).equals(PlayerClassType::BERSERKER)) {
                 do_cmd_attack(player_ptr, pos.y, pos.x, HISSATSU_NONE);
                 can_move = false;
             } else if (monster_can_cross_terrain(player_ptr, floor.get_grid(player_ptr->get_position()).feat, monrace, 0)) {

--- a/src/action/racial-execution.cpp
+++ b/src/action/racial-execution.cpp
@@ -68,7 +68,7 @@ PERCENTAGE racial_chance(PlayerType *player_ptr, rpi_type *rpi_ptr)
     }
 
     auto special_easy = PlayerClass(player_ptr).equals(PlayerClassType::IMITATOR);
-    special_easy &= player_ptr->inventory[INVEN_NECK]->is_specific_artifact(FixedArtifactId::GOGO_PENDANT);
+    special_easy &= player_ptr->is_wielding(FixedArtifactId::GOGO_PENDANT);
     special_easy &= rpi_ptr->racial_name == _("倍返し", "Double Revenge");
     if (special_easy) {
         difficulty -= 12;

--- a/src/cmd-action/cmd-attack.cpp
+++ b/src/cmd-action/cmd-attack.cpp
@@ -194,12 +194,8 @@ bool do_cmd_attack(PlayerType *player_ptr, POSITION y, POSITION x, combat_option
 
     const auto is_confused = effects->confusion().is_confused();
     const auto is_stunned = effects->stun().is_stunned();
-    if (is_female(monrace) && !(is_stunned || is_confused || is_hallucinated || !m_ptr->ml)) {
-        // @todo 「特定の武器を装備している」旨のメソッドを別途作る
-        constexpr auto zantetsu = FixedArtifactId::ZANTETSU;
-        const auto is_main_hand_zantetsu = player_ptr->inventory[INVEN_MAIN_HAND]->is_specific_artifact(zantetsu);
-        const auto is_sub_hand_zantetsu = player_ptr->inventory[INVEN_SUB_HAND]->is_specific_artifact(zantetsu);
-        if (is_main_hand_zantetsu || is_sub_hand_zantetsu) {
+    if (monrace.is_female() && !(is_stunned || is_confused || is_hallucinated || !m_ptr->ml)) {
+        if (player_ptr->is_wielding(FixedArtifactId::ZANTETSU)) {
             sound(SoundKind::ATTACK_FAILED);
             msg_print(_("拙者、おなごは斬れぬ！", "I can not attack women!"));
             return false;
@@ -213,17 +209,7 @@ bool do_cmd_attack(PlayerType *player_ptr, POSITION y, POSITION x, combat_option
     }
 
     if (!m_ptr->is_hostile() && !(is_stunned || is_confused || is_hallucinated || is_shero(player_ptr) || !m_ptr->ml)) {
-        constexpr auto stormbringer = FixedArtifactId::STORMBRINGER;
-        auto is_stormbringer = false;
-        if (player_ptr->inventory[INVEN_MAIN_HAND]->is_specific_artifact(stormbringer)) {
-            is_stormbringer = true;
-        }
-
-        if (player_ptr->inventory[INVEN_SUB_HAND]->is_specific_artifact(stormbringer)) {
-            is_stormbringer = true;
-        }
-
-        if (is_stormbringer) {
+        if (player_ptr->is_wielding(FixedArtifactId::STORMBRINGER)) {
             msg_format(_("黒い刃は強欲に%sを攻撃した！", "Your black blade greedily attacks %s!"), m_name.data());
             chg_virtue(player_ptr, Virtue::INDIVIDUALISM, 1);
             chg_virtue(player_ptr, Virtue::HONOUR, -1);

--- a/src/cmd-action/cmd-mane.cpp
+++ b/src/cmd-action/cmd-mane.cpp
@@ -279,7 +279,7 @@ static int get_mane_power(PlayerType *player_ptr, int *sn, bool baigaesi)
 
                     chance += player_ptr->to_m_chance;
 
-                    if (player_ptr->inventory[INVEN_NECK]->is_specific_artifact(FixedArtifactId::GOGO_PENDANT)) {
+                    if (player_ptr->is_wielding(FixedArtifactId::GOGO_PENDANT)) {
                         chance -= 10;
                     }
 

--- a/src/combat/shoot.cpp
+++ b/src/combat/shoot.cpp
@@ -336,7 +336,7 @@ static MULTIPLY calc_shot_damage_with_slay(
             }
 
             auto can_eliminate_smaug = arrow_ptr->is_specific_artifact(FixedArtifactId::BARD_ARROW);
-            can_eliminate_smaug &= player_ptr->inventory[INVEN_BOW]->is_specific_artifact(FixedArtifactId::BARD);
+            can_eliminate_smaug &= player_ptr->is_wielding(FixedArtifactId::BARD);
             can_eliminate_smaug &= monster.r_idx == MonraceId::SMAUG;
             if (can_eliminate_smaug) {
                 mult *= 5;

--- a/src/inventory/inventory-slot-types.h
+++ b/src/inventory/inventory-slot-types.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "util/enum-range.h"
+
 enum inventory_slot_type : short {
     INVEN_PACK = 23, /*!< アイテムスロット…所持品(0～) */
     INVEN_MAIN_HAND = 24, /*!< アイテムスロット…利手 */
@@ -19,3 +21,6 @@ enum inventory_slot_type : short {
     INVEN_NONE = 1000, /*!< アイテムスロット非選択状態 */
     INVEN_FORCE = 1111, /*!< inventory slot for selecting force (hard-coded). */
 };
+
+/** 装備スロットの範囲  */
+constexpr auto INVEN_WIELDING_SLOTS = EnumRangeInclusive(INVEN_MAIN_HAND, INVEN_FEET);

--- a/src/player-info/alignment.cpp
+++ b/src/player-info/alignment.cpp
@@ -91,12 +91,7 @@ void PlayerAlignment::update_alignment()
         THROW_EXCEPTION(std::logic_error, "Invalid MimicKindType was specified!");
     }
 
-    for (int i = 0; i < 2; i++) {
-        const auto &wielding_weapon = *this->player_ptr->inventory[INVEN_MAIN_HAND + i];
-        if (!has_melee_weapon(this->player_ptr, INVEN_MAIN_HAND + i) || !wielding_weapon.is_specific_artifact(FixedArtifactId::IRON_BALL)) {
-            continue;
-        }
-
+    if (this->player_ptr->is_wielding(FixedArtifactId::IRON_BALL)) {
         this->bias_evil_alignment(1000);
     }
 

--- a/src/player/player-status.cpp
+++ b/src/player/player-status.cpp
@@ -3128,7 +3128,7 @@ bool is_shero(PlayerType *player_ptr)
 
 bool is_echizen(PlayerType *player_ptr)
 {
-    return (player_ptr->ppersonality == PERSONALITY_COMBAT) || (player_ptr->inventory[INVEN_BOW]->is_specific_artifact(FixedArtifactId::CRIMSON));
+    return (player_ptr->ppersonality == PERSONALITY_COMBAT) || player_ptr->is_wielding(FixedArtifactId::CRIMSON);
 }
 
 bool is_tough(PlayerType *player_ptr)

--- a/src/system/player-type-definition.cpp
+++ b/src/system/player-type-definition.cpp
@@ -96,6 +96,21 @@ bool PlayerType::is_fully_healthy() const
     return is_fully_healthy;
 }
 
+/*!
+ * @brief 指定した固定アーティファクトを装備しているかどうか調べる
+ *
+ * @param fa_id 固定アーティファクトのID
+ * @return 装備していればtrue、そうでなければfalse
+ */
+bool PlayerType::is_wielding(FixedArtifactId fa_id) const
+{
+    return ranges::any_of(INVEN_WIELDING_SLOTS,
+        [&](auto slot) {
+            const auto &item = this->inventory[slot];
+            return item->is_valid() && item->is_specific_artifact(fa_id);
+        });
+}
+
 /*
  * @brief ランダムに1つアビリティスコアを減少させる
  * @return アビリティスコア減少メッセージ

--- a/src/system/player-type-definition.h
+++ b/src/system/player-type-definition.h
@@ -41,6 +41,7 @@ enum class INCIDENT {
 
 enum class DungeonId;
 enum class ElementRealmType;
+enum class FixedArtifactId : short;
 enum class ItemKindType : short;
 enum class MimicKindType;
 enum class MonraceId : short;
@@ -412,6 +413,7 @@ public:
     void ride_monster(MONSTER_IDX m_idx);
     std::shared_ptr<TimedEffects> effects() const;
     bool is_fully_healthy() const;
+    bool is_wielding(FixedArtifactId fa_id) const;
     std::string decrease_ability_random();
     std::string decrease_ability_all();
     Pos2D get_position() const;


### PR DESCRIPTION
プレイヤーが指定した固定アーティファクトを装備しているかどうかを調べる
メンバ関数 PlayerType::is_wielding() を実装し、これを使える箇所を
置き換えて可読性を向上する。