### PR TITLE
(Monster)[Update] 召喚親子の表記修正。

### DIFF
--- a/src/monster/monster-describer.cpp
+++ b/src/monster/monster-describer.cpp
@@ -250,11 +250,15 @@ std::string monster_desc(PlayerType *player_ptr, const MonsterEntity &monster, B
     std::stringstream ss;
 
     if (monster.parent_m_idx > 0) {
-        auto parent_name = player_ptr->current_floor_ptr->m_list[monster.parent_m_idx].get_monrace().name;
-        if (monster.mflag2.has(MonsterConstantFlagType::QUYLTHLUG_BORN)) {
-            ss << parent_name << _("が産んだ", "-born ");
-        } else {
-            ss << parent_name << _("が召喚した", "summoned ");
+        const auto parent_monster = player_ptr->current_floor_ptr->m_list[monster.parent_m_idx];
+        // 親ID＝自身のIDでは主を失った状態なのでスキップ
+        if (parent_monster.r_idx != monster.r_idx) {
+            auto parent_name = player_ptr->current_floor_ptr->m_list[monster.parent_m_idx].get_monrace().name;
+            if (monster.mflag2.has(MonsterConstantFlagType::QUYLTHLUG_BORN)) {
+                ss << parent_name << _("が産んだ", "-born ");
+            } else {
+                ss << parent_name << _("が召喚した", "summoned ");
+            }
         }
     }
 

--- a/src/monster/monster-processor.cpp
+++ b/src/monster/monster-processor.cpp
@@ -364,7 +364,11 @@ bool vanish_summoned_children(PlayerType *player_ptr, MONSTER_IDX m_idx, bool se
 
     if (see_m) {
         const auto m_name = monster_desc(player_ptr, monster, 0);
-        msg_format(_("%sは消え去った！", "%s^ disappears!"), m_name.data());
+        if (monster.mflag2.has(MonsterConstantFlagType::QUYLTHLUG_BORN)) {
+            msg_format(_("%sは崩壊して朽ち果てた。", "%s^ crumbles into dust."), m_name.data());
+        } else {
+            msg_format(_("%sは消え去った！", "%s^ disappears!"), m_name.data());
+        }
     }
 
     if (record_named_pet && monster.is_named_pet()) {


### PR DESCRIPTION
 * すでに `vanish_summoned_children()` が存在していたのでクイルスルグ生まれの消滅描写を修正。
 * `monster_desc()` で親を失った場合の表記に対応。